### PR TITLE
[StripeBundle] Allow to call notifyPaymentOrderFail

### DIFF
--- a/src/PaymentSuite/StripeBundle/Services/Wrapper/StripeTransactionWrapper.php
+++ b/src/PaymentSuite/StripeBundle/Services/Wrapper/StripeTransactionWrapper.php
@@ -16,8 +16,6 @@ namespace PaymentSuite\StripeBundle\Services\Wrapper;
 use Stripe;
 use Stripe_Charge;
 
-use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
-
 /**
  * Stripe transaction wrapper
  */
@@ -55,7 +53,8 @@ class StripeTransactionWrapper
             $charge = Stripe_Charge::create($params);
             $chargeData = json_decode($charge, true);
         } catch (\Exception $e) {
-            throw new PaymentException();
+            // The way to get to 'notifyPaymentOrderFail'
+            return array('paid' => 0);
         }
 
         return $chargeData;

--- a/src/PaymentSuite/StripeBundle/Services/Wrapper/StripeTransactionWrapper.php
+++ b/src/PaymentSuite/StripeBundle/Services/Wrapper/StripeTransactionWrapper.php
@@ -44,7 +44,6 @@ class StripeTransactionWrapper
      * @param array $params Set of params
      *
      * @return array            Result of transaction
-     * @throws PaymentException
      */
     public function create(array $params)
     {


### PR DESCRIPTION
For example if you use a `cart_declined` StripeTransactionWrapper::create will throw PaymentException and will go directlly to the fail action in the conntroller without passing by `notifyPaymentOrderFail`