### PR TITLE
Normalized amounts to cents

### DIFF
--- a/src/PaymentSuite/BanwireBundle/Form/Type/BanwireType.php
+++ b/src/PaymentSuite/BanwireBundle/Form/Type/BanwireType.php
@@ -118,7 +118,7 @@ class BanwireType extends AbstractType
              * Some hidden fields
              */
             ->add('amount', 'hidden', array(
-                'data'  =>  $this->paymentBridge->getAmount() * 100
+                'data'  =>  $this->paymentBridge->getAmount()
             ))
             ->add('submit', 'submit');
     }

--- a/src/PaymentSuite/BanwireBundle/Services/BanwireManager.php
+++ b/src/PaymentSuite/BanwireBundle/Services/BanwireManager.php
@@ -91,7 +91,7 @@ class BanwireManager
         /**
          * first check that amounts are the same
          */
-        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount() * 100;
+        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount();
         /**
          * If both amounts are different, execute Exception
          */
@@ -133,7 +133,7 @@ class BanwireManager
             'user'            => $this->user,
             'reference'       => $this->paymentBridge->getOrderId() . '#' . date('Ymdhis'),
             'currency'        => $this->paymentBridge->getCurrency(),
-            'ammount'         => number_format($this->paymentBridge->getAmount(), 2) * 100,
+            'ammount'         => number_format($this->paymentBridge->getAmount(), 2),
             'concept'         => $this->paymentBridge->getOrderDescription(),
             'card_num'        => $paymentMethod->getCardNum(),
             'card_name'       => $paymentMethod->getCardName(),

--- a/src/PaymentSuite/BanwireGatewayBundle/Services/Wrapper/BanwireGatewayTypeWrapper.php
+++ b/src/PaymentSuite/BanwireGatewayBundle/Services/Wrapper/BanwireGatewayTypeWrapper.php
@@ -118,7 +118,8 @@ class BanwireGatewayTypeWrapper
                 'data'  =>  $this->user,
             ))
             ->add('gran_total', 'hidden', array(
-                'data'  =>   $this->paymentBridge->getAmount(),//number_format($this->paymentBridge->getAmount(), 2) * 100
+                'data'  =>   $this->paymentBridge->getAmount(),
+                //number_format($this->paymentBridge->getAmount(), 2)
             ))
             ->add('referencia_ext', 'hidden', array(
                 'data'  =>  $this->paymentBridge->getOrderDescription()

--- a/src/PaymentSuite/DineroMailApiBundle/Form/Type/DineromailApiType.php
+++ b/src/PaymentSuite/DineroMailApiBundle/Form/Type/DineromailApiType.php
@@ -138,7 +138,7 @@ class DineromailApiType extends AbstractType
              * Some hidden fields
              */
             ->add('amount', 'hidden', array(
-                'data'  =>  $this->paymentBridge->getAmount() * 100
+                'data'  =>  $this->paymentBridge->getAmount()
             ))
             ->add('submit', 'submit');
     }

--- a/src/PaymentSuite/DineroMailApiBundle/Services/DineromailApiManager.php
+++ b/src/PaymentSuite/DineroMailApiBundle/Services/DineromailApiManager.php
@@ -128,7 +128,7 @@ class DineromailApiManager
     public function processPayment(DineromailApiMethod $paymentMethod, $amount)
     {
         /// first check that amounts are the same
-        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount() * 100;
+        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount();
         /**
          * If both amounts are different, execute Exception
          */

--- a/src/PaymentSuite/DineroMailBundle/Services/Wrapper/DineromailTypeWrapper.php
+++ b/src/PaymentSuite/DineroMailBundle/Services/Wrapper/DineromailTypeWrapper.php
@@ -161,7 +161,7 @@ class DineromailTypeWrapper
              * Payment bridge data
              */
             ->add('amount', 'hidden', array(
-                'data'  =>  number_format($this->paymentBridge->getAmount(), 2) * 100
+                'data'  =>  number_format($this->paymentBridge->getAmount(), 2)
             ))
             ->add('transaction_id', 'hidden', array(
                 'data'  =>  $dineromailTransactionId

--- a/src/PaymentSuite/PagosOnlineBundle/Form/Type/PagosonlineType.php
+++ b/src/PaymentSuite/PagosOnlineBundle/Form/Type/PagosonlineType.php
@@ -124,7 +124,7 @@ class PagosonlineType extends AbstractType
              * Some hidden fields
              */
             ->add('amount', 'hidden', array(
-                'data'  =>  $this->paymentBridge->getAmount() * 100
+                'data'  =>  $this->paymentBridge->getAmount()
             ))
             ->add('submit', 'submit');
     }

--- a/src/PaymentSuite/PagosOnlineBundle/Services/PagosonlineManager.php
+++ b/src/PaymentSuite/PagosOnlineBundle/Services/PagosonlineManager.php
@@ -89,7 +89,7 @@ class PagosonlineManager
     public function processPayment(PagosonlineMethod $paymentMethod, $amount)
     {
         /// first check that amounts are the same
-        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount() * 100;
+        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount();
         /**
          * If both amounts are different, execute Exception
          */

--- a/src/PaymentSuite/PaymentCoreBundle/Services/Interfaces/PaymentBridgeInterface.php
+++ b/src/PaymentSuite/PaymentCoreBundle/Services/Interfaces/PaymentBridgeInterface.php
@@ -25,17 +25,20 @@ interface PaymentBridgeInterface
      */
 
     /**
-     * Set order to PaymentBridge
+     * Sets order to PaymentBridge
      *
-     * Given an order ( this object is not hinted, so every project must have its own order )
-     * we store it locally.
+     * Sets a generic Order object in the PaymentBridge.
+     * This is necessary so that the bridge has a reference to
+     * the order object once it gets loaded.
+     * The order object doesn't need to implement any interface,
+     * since it is platform-specific
      *
      * @param Object $order Order element
      */
     public function setOrder($order);
 
     /**
-     * Get order
+     * Gets order
      *
      * Return object stored as order
      *
@@ -44,7 +47,7 @@ interface PaymentBridgeInterface
     public function getOrder();
 
     /**
-     * Get order given an identifier and stores locally
+     * Gets order given an identifier and stores it ocally
      *
      * @param integer $orderId Order identifier, usually defined as primary key or unique key
      *
@@ -53,14 +56,14 @@ interface PaymentBridgeInterface
     public function findOrder($orderId);
 
     /**
-     * Return order identifier value
+     * Returns order identifier value
      *
      * @return integer
      */
     public function getOrderId();
 
     /**
-     * Return if order has already been paid
+     * Returns if order has already been paid
      *
      * @return boolean
      */
@@ -71,15 +74,22 @@ interface PaymentBridgeInterface
      */
 
     /**
-     * Get payment amount
-     * Amount charged in cents
+     * Gets payment amount in CENTS
      *
-     * @return float
+     * Payment amoounts always must be returned in CENTS
+     * Example:
+     *   USD: 10.55 -> becomes "1055"
+     *
+     * This means that if your platform uses floats/decimals to
+     * specify amounts, you will have to convert them to
+     * integer before returning them here
+     *
+     * @return integer
      */
     public function getAmount();
 
     /**
-     * Get payment currency
+     * Gets payment currency in ISO 4217 3-character format
      *
      * @return string
      */

--- a/src/PaymentSuite/PaymillBundle/Form/Type/PaymillType.php
+++ b/src/PaymentSuite/PaymillBundle/Form/Type/PaymillType.php
@@ -127,7 +127,7 @@ class PaymillType extends AbstractType
             ))
             ->add('credit_card_expiration_year', 'choice', array(
                 'required' => true,
-                'choices' => array_combine(range(2013, 2025), range(2013, 2025)),
+                'choices' => array_combine(range(date('Y'), 2025), range(date('Y'), 2025)),
             ))
 
             /**
@@ -142,7 +142,7 @@ class PaymillType extends AbstractType
              * Some hidden fields
              */
             ->add('amount', 'hidden', array(
-                'data'  =>  number_format($this->paymentBridge->getAmount(), 2) * 100
+                'data'  =>  $this->paymentBridge->getAmount()
             ))
             ->add('api_token', 'hidden', array(
                 'data'  =>  ''

--- a/src/PaymentSuite/PaymillBundle/Services/PaymillManager.php
+++ b/src/PaymentSuite/PaymillBundle/Services/PaymillManager.php
@@ -83,7 +83,7 @@ class PaymillManager
     public function processPayment(PaymillMethod $paymentMethod, $amount)
     {
         /// first check that amounts are the same
-        $paymentBridgeAmount = (float) $this->paymentBridge->getAmount() * 100;
+        $paymentBridgeAmount = intval($this->paymentBridge->getAmount());
 
         /**
          * If both amounts are different, execute Exception
@@ -118,7 +118,7 @@ class PaymillManager
          */
         $extraData = $this->paymentBridge->getExtraData();
         $params = array(
-            'amount'      => intval($paymentBridgeAmount),
+            'amount'      => $paymentBridgeAmount,
             'currency'    => $this->paymentBridge->getCurrency(),
             'token'       => $paymentMethod->getApiToken(),
             'description' => $extraData['order_description'],

--- a/src/PaymentSuite/PaypalExpressCheckoutBundle/Form/Type/PaypalExpressCheckoutType.php
+++ b/src/PaymentSuite/PaypalExpressCheckoutBundle/Form/Type/PaypalExpressCheckoutType.php
@@ -75,7 +75,7 @@ class PaypalExpressCheckoutType extends AbstractType
              * Some hidden fields
              */
             ->add('amount', 'hidden', array(
-                'data'  =>  number_format($this->paymentBridge->getAmount(), 2) * 100
+                'data'  =>  $this->paymentBridge->getAmount()
             ))
             ->add('currency', 'hidden', array(
                 'data'  =>  $this->paymentBridge->getCurrency()

--- a/src/PaymentSuite/RedsysBundle/Services/Wrapper/RedsysFormTypeWrapper.php
+++ b/src/PaymentSuite/RedsysBundle/Services/Wrapper/RedsysFormTypeWrapper.php
@@ -137,7 +137,7 @@ class RedsysFormTypeWrapper
             ->urlFactory
             ->getReturnUrlKoForOrderId($orderId);
 
-        $Ds_Merchant_Amount             = (integer) ($this->paymentBridge->getAmount() * 100);
+        $Ds_Merchant_Amount             = $this->paymentBridge->getAmount();
         $Ds_Merchant_Order              = $this->formatOrderNumber($this->paymentBridge->getOrderNumber());
         $Ds_Merchant_MerchantCode       = $this->merchantCode;
         $Ds_Merchant_Currency           = $this->currencyTranslation($this->paymentBridge->getCurrency());

--- a/src/PaymentSuite/SafetyPayBundle/Services/Wrapper/SafetypayTypeWrapper.php
+++ b/src/PaymentSuite/SafetyPayBundle/Services/Wrapper/SafetypayTypeWrapper.php
@@ -123,7 +123,7 @@ class SafetypayTypeWrapper
             'Apikey'                => $this->key,
             'RequestDateTime'       => $this->safetyPayManager->getRequestDateTime(),
             'CurrencyCode'          => $this->paymentBridge->getCurrency(),
-            'Amount'                => number_format($this->paymentBridge->getAmount(), 2, '.', ''),
+            'Amount'                => number_format($this->paymentBridge->getAmount() / 100, 2, '.', ''),
             'MerchantReferenceNo'   => $safetyPayTransaction,
             'Language'              => 'ES',
             'TrackingCode'          => '',

--- a/src/PaymentSuite/StripeBundle/Form/Type/StripeType.php
+++ b/src/PaymentSuite/StripeBundle/Form/Type/StripeType.php
@@ -63,7 +63,7 @@ class StripeType extends AbstractType
             ))
             ->add('credit_cart_expiration_year', 'choice', array(
                 'required' => true,
-                'choices' => array_combine(range(2013, 2025), range(2013, 2025)),
+                'choices' => array_combine(range(date('Y'), 2025), range(date('Y'), 2025)),
             ))
             ->add('amount', 'hidden', array(
                 'data'  =>  $this->paymentBridge->getAmount()

--- a/src/PaymentSuite/StripeBundle/Services/StripeManager.php
+++ b/src/PaymentSuite/StripeBundle/Services/StripeManager.php
@@ -86,7 +86,7 @@ class StripeManager
     private function prepareData(StripeMethod $paymentMethod, $amount)
     {
         /// first check that amounts are the same
-        $cartAmount = (float) $this->paymentBridge->getAmount();
+        $cartAmount = intval($this->paymentBridge->getAmount());
 
         /**
          * If both amounts are different, execute Exception
@@ -136,7 +136,7 @@ class StripeManager
 
         $this->chargeParams = array(
             'card'     => $cardParams,
-            'amount'   => intval($cartAmount),
+            'amount'   => $cartAmount,
             'currency' => strtolower($this->paymentBridge->getCurrency()),
         );
 

--- a/src/PaymentSuite/WebpayBundle/Services/WebpayManager.php
+++ b/src/PaymentSuite/WebpayBundle/Services/WebpayManager.php
@@ -69,7 +69,7 @@ class WebpayManager
     public function processPayment()
     {
         $orderId = $this->paymentBridge->getOrderId();
-        $amount = floor($this->paymentBridge->getAmount() * 100);
+        $amount = $this->paymentBridge->getAmount();
         $sessionId = $orderId . date('Ymdhis');
 
         // Generate session log file for KCC

--- a/src/PaymentSuite/WebpayBundle/Services/Wrapper/WebpayTypeWrapper.php
+++ b/src/PaymentSuite/WebpayBundle/Services/Wrapper/WebpayTypeWrapper.php
@@ -75,7 +75,7 @@ class WebpayTypeWrapper
             ->setAction($this->cgiUri . '/tbk_bp_pago.cgi')
             ->setMethod('POST')
             ->add('TBK_TIPO_TRANSACCION', 'hidden', array('data' => 'TR_NORMAL'))
-            ->add('TBK_MONTO', 'hidden', array('data' => floor($this->paymentBridge->getAmount() * 100)))
+            ->add('TBK_MONTO', 'hidden', array('data' => $this->paymentBridge->getAmount()))
             ->add('TBK_ORDEN_COMPRA', 'hidden', array('data' => $this->paymentBridge->getOrderId()))
             ->add('TBK_ID_SESION', 'hidden', array('data' => $sessionId))
             ->add('TBK_URL_EXITO', 'hidden', array('data' => $okRoute))


### PR DESCRIPTION
**This is a BC incompatible PR**

Several payment bundles assumed that the amounts returned by `PaymentBridgeInterface` implementations were `float`.

This is **NOT** the case, since payment bridges should **always** return amounts in **cents** (specified as integers)

I.E. `PaymentBridgeInterface::getAmount()` must return `1055` when we are talking about `$10.55`.

This PR explains it more vocally in the `PaymentBridgeInterface` docblock, however there are many payment methods who where treating the amount as decimal/floats. Examples:

* https://github.com/PaymentSuite/paymentsuite/compare/fix/normalize-amount-to-cent?expand=1#diff-9f42a637b50efc1e0c0c3057822a3603L121
* https://github.com/PaymentSuite/paymentsuite/compare/fix/normalize-amount-to-cent?expand=1#diff-4f091b4b86962ceda984ab5751d96f85L141
* https://github.com/PaymentSuite/paymentsuite/compare/fix/normalize-amount-to-cent?expand=1#diff-f1c4b41241458c956e2042eced3353f5L126
* https://github.com/PaymentSuite/paymentsuite/compare/fix/normalize-amount-to-cent?expand=1#diff-65a46c069be7abd0235a49acdc0c7755L140

It is surely not optimal to propose this change so abruptly, but it is better to fix this ASAP before things get worse. 

The bad thing is that we do not know how concrete `PaymentBridgeInterface`s were implemented, because actual implementations are out of our control.

Any suggestion on how to mitigate the forthcoming problems?

Ping @PaymentSuite/collaborators @PaymentSuite/owners @scastells 

