### PR TITLE
Fixed typo in class that executes paypal request

### DIFF
--- a/src/PaymentSuite/PaypalExpressCheckoutBundle/Services/Wrapper/PaypalExpressCheckoutTransactionWrapper.php
+++ b/src/PaymentSuite/PaypalExpressCheckoutBundle/Services/Wrapper/PaypalExpressCheckoutTransactionWrapper.php
@@ -65,7 +65,7 @@ class PaypalExpressCheckoutTransactionWrapper
         } else {
             if ($responseArray['ACK'] == 'Success') {
                 curl_close($curl);
-                $this->reponse = $responseArray;
+                $this->response = $responseArray;
             } else {
                 $this->errors = $responseArray;
                 curl_close($curl);


### PR DESCRIPTION
Small PR to fix an error with a variable. This variable saves the response from paypal, so is important.