### PR TITLE
Improve bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
-  - hhvm
   - 7.0
+  - 7.1
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ commit
 [Gitter](http://gitter.im/paymentsuite/paymentsuite) and we'll try to help you
 as much as possible
 * Look for some help on [Stackoverflow](http://stackoverflow.com)
-* As a last resort, look at [google](http://google.com)!

--- a/composer.json
+++ b/composer.json
@@ -21,25 +21,24 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
-        "symfony/finder": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
+        "php": "^5.5|^7.0",
+        "symfony/finder": "^2.8|^3.0",
+        "symfony/config": "^2.8|^3.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/form": "^2.8|^3.0",
+        "symfony/http-kernel": "^2.8|^3.0",
+        "symfony/dependency-injection": "^2.8|^3.0",
+        "symfony/options-resolver": "^2.8|^3.0",
         "mmoreram/symfony-bundle-dependencies": "^1.0",
-
         "psr/log": "^1.0",
         "twig/twig": "^1.23.1",
         "stripe/stripe-php": "3.4.0",
-        "monolog/monolog": "^1.17"
+        "monolog/monolog": "^1.17",
+        "wearemarketing/paylands-php": "dev-master"
     },
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-
         "mmoreram/php-formatter": "1.1.0",
         "fabpot/php-cs-fixer": "1.11",
         "phpunit/phpunit": "^4.8.19"
@@ -50,7 +49,8 @@
         "paymentsuite/payment-core-bundle": "self.version",
         "paymentsuite/paypal-web-checkout-bundle": "self.version",
         "paymentsuite/redsys-bundle": "self.version",
-        "paymentsuite/stripe-bundle": "self.version"
+        "paymentsuite/stripe-bundle": "self.version",
+        "paymentsuite/paylands-bundle": "self.version"
     },
     "autoload": {
         "psr-4": {
@@ -59,7 +59,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     },
     "scripts": {

--- a/src/PaymentSuite/PaylandsBundle/Controller/PaymentController.php
+++ b/src/PaymentSuite/PaylandsBundle/Controller/PaymentController.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Controller;
+
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
+use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+use PaymentSuite\PaylandsBundle\Services\PaylandsManager;
+use PaymentSuite\PaylandsBundle\Services\PaylandsFormFactory;
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRouteCollection;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Class PaymentController.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaymentController extends Controller
+{
+    /**
+     * @var PaylandsManager
+     *
+     * Payment manager
+     */
+    private $paymentManager;
+
+    /**
+     * @var PaylandsFormFactory
+     *
+     * Method factory
+     */
+    private $paymentFormFactory;
+
+    /**
+     * @var RedirectionRouteCollection
+     *
+     * Redirection routes
+     */
+    private $redirectionRoutes;
+
+    /**
+     * @var PaymentBridgeInterface
+     *
+     * Payment bridge
+     */
+    private $paymentBridge;
+
+    /**
+     * @var UrlGeneratorInterface
+     *
+     * Url generator
+     */
+    private $urlGenerator;
+
+    /**
+     * PaymentController constructor.
+     *
+     * @param PaylandsManager                     $paymentManager
+     * @param PaylandsFormFactory                 $paymentFormFactory
+     * @param RedirectionRouteCollection $redirectionRoutes
+     * @param PaymentBridgeInterface              $paymentBridge
+     * @param UrlGeneratorInterface               $urlGenerator
+     */
+    public function __construct(
+        PaylandsManager $paymentManager,
+        PaylandsFormFactory $paymentFormFactory,
+        RedirectionRouteCollection $redirectionRoutes,
+        PaymentBridgeInterface $paymentBridge,
+        UrlGeneratorInterface $urlGenerator
+    ) {
+        $this->paymentManager = $paymentManager;
+        $this->paymentFormFactory = $paymentFormFactory;
+        $this->redirectionRoutes = $redirectionRoutes;
+        $this->paymentBridge = $paymentBridge;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function executeAction(Request $request)
+    {
+        /**
+         * @var FormInterface
+         */
+        $form = $this
+            ->paymentFormFactory
+            ->create();
+
+        $form->handleRequest($request);
+
+        $redirect = $this
+            ->redirectionRoutes
+            ->getRedirectionRoute('success');
+
+        try {
+            if (!$form->isValid()) {
+                throw new PaymentException();
+            }
+
+            $paymentMethod = $form->getData();
+
+            $this
+                ->paymentManager
+                ->processPayment($paymentMethod);
+        } catch (\Exception $e) {
+
+            /**
+             * Must redirect to fail route.
+             */
+            $redirect = $this
+                ->redirectionRoutes
+                ->getRedirectionRoute('failure');
+        }
+
+        $redirectUrl = $this
+            ->urlGenerator
+            ->generate(
+                $redirect->getRoute(),
+                $redirect->getRouteAttributes(
+                    $this->paymentBridge->getOrderId()
+                )
+            );
+
+        return new RedirectResponse($redirectUrl);
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/PaylandsBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\DependencyInjection;
+
+use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteConfiguration;
+use WAM\Paylands\ClientInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+/**
+ * Class Configuration.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class Configuration extends AbstractPaymentSuiteConfiguration
+{
+    const API_CLIENT_DEFAULT = 'paymentsuite.paylands.api.client_default';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('paylands');
+
+        $rootNode
+            ->children()
+                ->scalarNode('api_key')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('signature')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('services')
+                    ->requiresAtLeastOneElement()
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('currency')->end()
+                            ->scalarNode('service')->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->scalarNode('validation_service')
+                    ->defaultNull()
+                ->end()
+                ->enumNode('operative')
+                    ->values([
+                        ClientInterface::OPERATIVE_AUTHORIZATION,
+                        ClientInterface::OPERATIVE_DEFERRED,
+                    ])
+                    ->defaultValue(ClientInterface::OPERATIVE_AUTHORIZATION)
+                ->end()
+                ->scalarNode('fallback_template_uuid')
+                    ->defaultValue('default')
+                ->end()
+                ->arrayNode('i18n_template_uuids')
+                    ->useAttributeAsKey('locale')
+                    ->prototype('scalar')
+                    ->end()
+                ->end()
+                ->scalarNode('url')
+                    ->defaultValue('https://ws-paylands.paynopain.com/v1/')
+                ->end()
+                ->booleanNode('sandbox')
+                    ->defaultFalse()
+                ->end()
+                ->scalarNode('url_sandbox')
+                    ->defaultValue('https://ws-paylands.paynopain.com/v1/sandbox/')
+                ->end()
+                ->arrayNode('templates')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('view')
+                            ->defaultValue('PaylandsBundle:Paylands:view.html.twig')
+                        ->end()
+                            ->scalarNode('scripts')
+                            ->defaultValue('PaylandsBundle:Paylands:scripts.html.twig')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('interfaces')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('http_client')
+                            ->defaultNull()
+                        ->end()
+                        ->scalarNode('request_factory')
+                            ->defaultNull()
+                        ->end()
+                        ->scalarNode('uri_factory')
+                            ->defaultNull()
+                        ->end()
+                    ->end()
+                ->end()
+                ->scalarNode('api_client')
+                    ->defaultValue(self::API_CLIENT_DEFAULT)
+                ->end()
+                ->append($this->addRouteConfiguration('payment_success'))
+                ->append($this->addRouteConfiguration('payment_failure'))
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/DependencyInjection/PaylandsExtension.php
+++ b/src/PaymentSuite/PaylandsBundle/DependencyInjection/PaylandsExtension.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\DependencyInjection;
+
+use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteExtension;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/**
+ * Class PaylandsExtension.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsExtension extends AbstractPaymentSuiteExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $this->addParameters($container, 'paylands', [
+                'api_key' => $config['api_key'],
+                'signature' => $config['signature'],
+                'operative' => $config['operative'],
+                'sandbox' => $config['sandbox'],
+                'fallback_template_uuid' => $config['fallback_template_uuid'],
+                'i18n_template_uuids' => $config['i18n_template_uuids'],
+                'api_url' => trim($config['sandbox'] ? $config['url_sandbox'] : $config['url'], " \t\n\r\0\x0B/"),
+                'view_template' => $config['templates']['view'],
+                'scripts_template' => $config['templates']['scripts'],
+                'validation_service' => $config['validation_service'],
+            ]
+        );
+
+        $this->registerRedirectRoutesDefinition($container, 'paylands', [
+                'success' => $config['payment_success'],
+                'failure' => $config['payment_failure'],
+            ]
+        );
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+
+        $this->registerApiClient($container, $config);
+    }
+
+    /**
+     * Registers the list of available currency dependant Paylands' services to use.
+     *
+     * @param ContainerBuilder $containerBuilder
+     * @param array            $config
+     */
+    protected function registerEndpointServices(ContainerBuilder $containerBuilder, array $config)
+    {
+        $resolverDefinition = $containerBuilder->getDefinition('paymentsuite.paylands.currency_service_resolver');
+
+        foreach ($config as $option) {
+            $resolverDefinition->addMethodCall('addService', [
+                $option['currency'],
+                $option['service'],
+            ]);
+        }
+    }
+
+    /**
+     * Resolves configuration of needed psr-7 interfaces. When null is provided, auto-discovery is used. When
+     * a service key is provided, that service is injected into related services instead.
+     *
+     * @param ContainerBuilder $containerBuilder
+     * @param array            $config
+     */
+    protected function resolveApiClientInterfaces(ContainerBuilder $containerBuilder, array $config)
+    {
+        $requestFactoryDefinition = $containerBuilder->getDefinition('paymentsuite.paylands.api.request_factory');
+
+        $requestFactoryDefinition->addMethodCall('setRequestFactory', [
+            $config['request_factory'] ? $containerBuilder->getDefinition($config['request_factory']) : null,
+        ]);
+
+        $clientFactoryDefinition = $containerBuilder->getDefinition('paymentsuite.paylands.api.client_factory');
+
+        $clientFactoryDefinition->addMethodCall('setHttpClient', [
+            $config['http_client'] ? $containerBuilder->getDefinition($config['http_client']) : null,
+        ]);
+
+        $clientFactoryDefinition->addMethodCall('setUriFactory', [
+            $config['uri_factory'] ? $containerBuilder->getDefinition($config['uri_factory']) : null,
+        ]);
+    }
+
+    /**
+     * Registers final API client to use, default or custom.
+     *
+     * @param ContainerBuilder $containerBuilder
+     * @param array            $config
+     */
+    protected function registerApiClient(ContainerBuilder $containerBuilder, $config)
+    {
+        $containerBuilder->setAlias('paymentsuite.paylands.api.client', $config['api_client']);
+
+        if (Configuration::API_CLIENT_DEFAULT == $config['api_client']) {
+            $this->resolveApiClientInterfaces($containerBuilder, $config['interfaces']);
+
+            $this->registerEndpointServices($containerBuilder, $config['services']);
+        }
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Exception/ApiErrorException.php
+++ b/src/PaymentSuite/PaylandsBundle/Exception/ApiErrorException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Exception;
+
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
+
+/**
+ * Class ApiErrorException.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class ApiErrorException extends PaymentException
+{
+}

--- a/src/PaymentSuite/PaylandsBundle/Exception/CardNotFoundException.php
+++ b/src/PaymentSuite/PaylandsBundle/Exception/CardNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Exception;
+
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
+
+/**
+ * Class CardNotFoundException.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class CardNotFoundException extends PaymentException
+{
+}

--- a/src/PaymentSuite/PaylandsBundle/Exception/CreateFormException.php
+++ b/src/PaymentSuite/PaylandsBundle/Exception/CreateFormException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Exception;
+
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
+
+/**
+ * Class CreateFormException.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class CreateFormException extends PaymentException
+{
+}

--- a/src/PaymentSuite/PaylandsBundle/Form/Type/PaylandsType.php
+++ b/src/PaymentSuite/PaylandsBundle/Form/Type/PaylandsType.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Form\Type;
+
+use PaymentSuite\PaylandsBundle\PaylandsMethod;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class PaylandsType.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('customerExternalId', HiddenType::class, [
+                'required' => true,
+            ])
+            ->add('customerToken', HiddenType::class, [
+                'required' => true,
+            ])
+            ->add('cardBin', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'bin',
+                ],
+            ])
+            ->add('cardBrand', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'brand',
+                ],
+            ])
+            ->add('cardCountry', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'country',
+                ],
+            ])
+            ->add('cardExpireMonth', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'expire_month',
+                ],
+            ])
+            ->add('cardExpireYear', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'expire_year',
+                ],
+            ])
+            ->add('cardLast4', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'last4',
+                ],
+            ])
+            ->add('cardType', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'type',
+                ],
+            ])
+            ->add('cardUuid', HiddenType::class, [
+                'required' => true,
+                'attr' => [
+                    'data-source' => 'uuid',
+                ],
+            ])
+            ->add('cardAdditional', HiddenType::class, [
+                'attr' => [
+                    'data-source' => 'additional',
+                ],
+            ])
+            ->add('onlyTokenizeCard', HiddenType::class, [
+                'required' => true,
+            ])
+            ->add('validate_button', ButtonType::class, [
+                'label' => 'paylands.label.validate_button',
+                'translation_domain' => 'PaylandsBundle',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => PaylandsMethod::class,
+        ]);
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/LICENSE
+++ b/src/PaymentSuite/PaylandsBundle/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2016 Marc Morera <yuhu@mmoreram.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/PaymentSuite/PaylandsBundle/PaylandsBundle.php
+++ b/src/PaymentSuite/PaylandsBundle/PaylandsBundle.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle;
+
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+use PaymentSuite\PaylandsBundle\DependencyInjection\PaylandsExtension;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Class PaylandsBundle.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsBundle extends Bundle implements DependentBundleInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensionClass()
+    {
+        return PaylandsExtension::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        return [
+            'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',
+        ];
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/PaylandsMethod.php
+++ b/src/PaymentSuite/PaylandsBundle/PaylandsMethod.php
@@ -1,0 +1,386 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle;
+
+use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
+
+/**
+ * Class PaylandsMethod.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+final class PaylandsMethod implements PaymentMethodInterface
+{
+    /**
+     * @var string
+     */
+    private $customerExternalId;
+
+    /**
+     * @var string
+     */
+    private $customerToken;
+
+    /**
+     * @var string
+     */
+    private $cardBin;
+
+    /**
+     * @var string
+     */
+    private $cardBrand;
+
+    /**
+     * @var string
+     */
+    private $cardCountry;
+
+    /**
+     * @var string
+     */
+    private $cardExpireMonth;
+
+    /**
+     * @var string
+     */
+    private $cardExpireYear;
+
+    /**
+     * @var string
+     */
+    private $cardLast4;
+
+    /**
+     * @var string
+     */
+    private $cardType;
+
+    /**
+     * @var string
+     */
+    private $cardUuid;
+
+    /**
+     * @var string
+     */
+    private $cardAdditional;
+
+    /**
+     * @var bool
+     */
+    private $onlyTokenizeCard;
+
+    /**
+     * @var array
+     */
+    private $paymentResult;
+
+    /**
+     * @var string
+     */
+    private $paymentStatus;
+
+    /**
+     * @return string
+     */
+    public function getCustomerExternalId()
+    {
+        return $this->customerExternalId;
+    }
+
+    /**
+     * @param string $customerExternalId
+     *
+     * @return PaylandsMethod
+     */
+    public function setCustomerExternalId($customerExternalId)
+    {
+        $this->customerExternalId = $customerExternalId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomerToken()
+    {
+        return $this->customerToken;
+    }
+
+    /**
+     * @param string $customerToken
+     *
+     * @return PaylandsMethod
+     */
+    public function setCustomerToken($customerToken)
+    {
+        $this->customerToken = $customerToken;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardBin()
+    {
+        return $this->cardBin;
+    }
+
+    /**
+     * @param string $cardBin
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardBin($cardBin)
+    {
+        $this->cardBin = $cardBin;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardBrand()
+    {
+        return $this->cardBrand;
+    }
+
+    /**
+     * @param string $cardBrand
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardBrand($cardBrand)
+    {
+        $this->cardBrand = $cardBrand;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardCountry()
+    {
+        return $this->cardCountry;
+    }
+
+    /**
+     * @param string $cardCountry
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardCountry($cardCountry)
+    {
+        $this->cardCountry = $cardCountry;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardExpireMonth()
+    {
+        return $this->cardExpireMonth;
+    }
+
+    /**
+     * @param string $cardExpireMonth
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardExpireMonth($cardExpireMonth)
+    {
+        $this->cardExpireMonth = $cardExpireMonth;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardExpireYear()
+    {
+        return $this->cardExpireYear;
+    }
+
+    /**
+     * @param string $cardExpireYear
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardExpireYear($cardExpireYear)
+    {
+        $this->cardExpireYear = $cardExpireYear;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardLast4()
+    {
+        return $this->cardLast4;
+    }
+
+    /**
+     * @param string $cardLast4
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardLast4($cardLast4)
+    {
+        $this->cardLast4 = $cardLast4;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardType()
+    {
+        return $this->cardType;
+    }
+
+    /**
+     * @param string $cardType
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardType($cardType)
+    {
+        $this->cardType = $cardType;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardUuid()
+    {
+        return $this->cardUuid;
+    }
+
+    /**
+     * @param string $cardUuid
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardUuid($cardUuid)
+    {
+        $this->cardUuid = $cardUuid;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCardAdditional()
+    {
+        return $this->cardAdditional;
+    }
+
+    /**
+     * @param string $cardAdditional
+     *
+     * @return PaylandsMethod
+     */
+    public function setCardAdditional($cardAdditional)
+    {
+        $this->cardAdditional = $cardAdditional;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOnlyTokenizeCard()
+    {
+        return $this->onlyTokenizeCard;
+    }
+
+    /**
+     * @param bool $onlyTokenizeCard
+     *
+     * @return PaylandsMethod
+     */
+    public function setOnlyTokenizeCard($onlyTokenizeCard)
+    {
+        $this->onlyTokenizeCard = $onlyTokenizeCard;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPaymentResult()
+    {
+        return $this->paymentResult;
+    }
+
+    /**
+     * @param array $paymentResult
+     *
+     * @return PaylandsMethod
+     */
+    public function setPaymentResult($paymentResult)
+    {
+        $this->paymentResult = $paymentResult;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentStatus()
+    {
+        return $this->paymentStatus;
+    }
+
+    /**
+     * @param string $paymentStatus
+     *
+     * @return PaylandsMethod
+     */
+    public function setPaymentStatus($paymentStatus)
+    {
+        $this->paymentStatus = $paymentStatus;
+
+        return $this;
+    }
+
+    /**
+     * Gets Paylands method name.
+     *
+     * @return string
+     */
+    public function getPaymentName()
+    {
+        return 'Paylands';
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/README.md
+++ b/src/PaymentSuite/PaylandsBundle/README.md
@@ -1,0 +1,1 @@
+# Paymentsuite - Paylands

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/routing.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+paymentsuite_paylands_execute:
+    path: /payment/paylands/execute
+    defaults:
+        _controller: paymentsuite.paylands.payment_controller:executeAction

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services.yml
@@ -1,0 +1,5 @@
+imports:
+  - { resource: services/api.yml }
+  - { resource: services/controllers.yml }
+  - { resource: services/payment.yml }
+  - { resource: services/twig.yml }

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/api.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/api.yml
@@ -1,0 +1,29 @@
+services:
+
+    paymentsuite.paylands.api.discovery_proxy:
+        class: WAM\Paylands\DiscoveryProxy
+
+    paymentsuite.paylands.api.request_factory:
+        class: WAM\Paylands\RequestFactory
+        public: false
+        arguments:
+            - '@paymentsuite.paylands.api.discovery_proxy'
+            - '%paymentsuite.paylands.signature%'
+
+    paymentsuite.paylands.api.client_factory:
+        class: WAM\Paylands\ClientFactory
+        public: false
+        arguments:
+            - '@paymentsuite.paylands.api.request_factory'
+            - '@paymentsuite.paylands.api.discovery_proxy'
+            - '%paymentsuite.paylands.api_key%'
+            - '%paymentsuite.paylands.api_url%'
+            - '%paymentsuite.paylands.sandbox%'
+
+    paymentsuite.paylands.api.client_default:
+        class: WAM\Paylands\Client
+        factory: ['@paymentsuite.paylands.api.client_factory', 'create']
+        public: false
+        calls:
+            - [setOperative, ['%paymentsuite.paylands.operative%']]
+            - [setTemplates, ['%paymentsuite.paylands.fallback_template_uuid%', '%paymentsuite.paylands.i18n_template_uuids%']]

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/controllers.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/controllers.yml
@@ -1,0 +1,10 @@
+services:
+
+    paymentsuite.paylands.payment_controller:
+        class: PaymentSuite\PaylandsBundle\Controller\PaymentController
+        arguments:
+            - '@paymentsuite.paylands.manager'
+            - '@paymentsuite.paylands.form_factory'
+            - '@paymentsuite.paylands.routes'
+            - '@paymentsuite.bridge'
+            - '@router'

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/payment.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/payment.yml
@@ -1,0 +1,33 @@
+services:
+
+    paymentsuite.paylands.form_factory:
+        class: PaymentSuite\PaylandsBundle\Services\PaylandsFormFactory
+        arguments:
+            - '@form.factory'
+            - '@router'
+
+    paymentsuite.paylands.manager:
+        class: PaymentSuite\PaylandsBundle\Services\PaylandsManager
+        arguments:
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
+            - '@paymentsuite.paylands.api.client'
+            - '@request_stack'
+            - '@paymentsuite.paylands.currency_service_resolver'
+
+    paymentsuite.paylands.view_renderer:
+        class: PaymentSuite\PaylandsBundle\Services\PaylandsViewRenderer
+        arguments:
+            - '@paymentsuite.paylands.api.client'
+            - '@paymentsuite.paylands.form_factory'
+            - '@paymentsuite.paylands.currency_service_resolver'
+            - '%paymentsuite.paylands.view_template%'
+            - '%paymentsuite.paylands.scripts_template%'
+
+    paymentsuite.paylands.currency_service_resolver:
+        class: PaymentSuite\PaylandsBundle\Services\PaylandsCurrencyServiceResolver
+        public: false
+        arguments:
+            - '@paymentsuite.bridge'
+        calls:
+            - ['setValidationService', ['%paymentsuite.paylands.validation_service%']]

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/twig.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/twig.yml
@@ -1,0 +1,8 @@
+services:
+
+    paymentsuite.paylands.twig_extension:
+        class: PaymentSuite\PaylandsBundle\Twig\PaylandsExtension
+        arguments:
+            - '@paymentsuite.paylands.view_renderer'
+        tags:
+            - { name: twig.extension }

--- a/src/PaymentSuite/PaylandsBundle/Resources/translations/PaylandsBundle.en.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/translations/PaylandsBundle.en.yml
@@ -1,0 +1,8 @@
+paylands:
+    label:
+        validate_button: Validate Card
+    error:
+        cardPan: Card number is not valid
+        cardCode: Card security code is not valid
+        cardExpiryDate: Card expire date is not valid
+        cardServer: Card not valid for the service

--- a/src/PaymentSuite/PaylandsBundle/Resources/translations/PaylandsBundle.es.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/translations/PaylandsBundle.es.yml
@@ -1,0 +1,8 @@
+paylands:
+    label:
+        validate_button: Validar Tarjeta
+    error:
+        cardPan: El número de tarjeta no es válido
+        cardCode: El código de seguridad no es válido
+        cardExpiryDate: La fecha de expiración no es válido
+        cardServer: Tarjeta no aceptada por el servicio

--- a/src/PaymentSuite/PaylandsBundle/Resources/views/Paylands/customize/card.html
+++ b/src/PaymentSuite/PaylandsBundle/Resources/views/Paylands/customize/card.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link href="https://ws-paylands.paynopain.com/css/bootstrap.min.css" rel="stylesheet">
+    <title>Gateway</title>
+</head>
+<body>
+<div class="container pull-left">
+    <div class="row">
+
+        <form action="" class="formTarjeta form_newcard" autocomplete="on" id="CardGatewayForm"
+              method="post" accept-charset="utf-8">
+
+            <div class="form-group col-xs-12 col-sm-4">
+                <input name="cardPan" autocorrect="off" autocapitalize="off"
+                       autocomplete="cc-num" placeholder="0000 0000 0000 0000"
+                       class="form-control cc-num" required="required" type="tel"
+                       id="CardPNPCardPan"/>
+            </div>
+
+            <div class="form-group col-xs-6 col-sm-2">
+                <input name="cardExpireFull" autocorrect="off" autocapitalize="off"
+                       autocomplete="cc-exp" placeholder="00/00"
+                       class="form-control cc-exp" required="required" type="tel"
+                       id="CardPNPCardExpireFull"/>
+            </div>
+
+            <div class="form-group col-xs-6 col-sm-2">
+                <input name="cvv2" autocorrect="off" autocapitalize="off"
+                       autocomplete="off" placeholder="CVV" class="form-control cc-cvc"
+                       required="required" type="tel" id="CardPNPCVV2"/>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script src="https://ws-paylands.paynopain.com/js/jquery.min.js"></script>
+<script src="https://ws-paylands.paynopain.com/js/bootstrap.min.js"></script>
+<script src="https://ws-paylands.paynopain.com/js/jquery.payment.js"></script>
+<script src="https://ws-paylands.paynopain.com/js/v1-card-iframe.js"></script>
+<script type="text/javascript">
+    $(document).ready(function () {
+
+        $('input.cc-num').payment('formatCardNumber');
+        $('input.cc-exp').payment('formatCardExpiry');
+        $('input.cc-cvc').payment('formatCardCVC');
+
+        $(document).on('blur', 'input.cc-num', function () {
+            if ($('input.cc-num').val().length == 0)
+                $(".ccType").hide();
+        });
+
+        $('form.form_newcard').on('submit', function (e) {
+            var cardType = $.payment.cardType($('.cc-num').val());
+
+            if (!$.payment.validateCardNumber($('.cc-num').val())) {
+                e.preventDefault();
+                alert("Número de tarjeta no válido");
+                return false;
+            }
+
+            if (!$.payment.validateCardExpiry($('.cc-exp').payment('cardExpiryVal'))) {
+                e.preventDefault();
+                alert("Fecha de caducidad no válida");
+                return false;
+            }
+
+            if (!$.payment.validateCardCVC($('.cc-cvc').val(), cardType)) {
+                e.preventDefault();
+                alert("Número de seguridad (CVV) no válido");
+                return false;
+            }
+
+            return true;
+        });
+
+        $('form.form_usecard').on('submit', function (e) {
+            if (!$.payment.validateCardCVC($('.cc2-cvc').val())) {
+                e.preventDefault();
+                alert("Número de seguridad (CVV) no válido");
+                return false;
+            }
+
+            $('.btn-submit').attr('disabled', 'disabled');
+            waitingDialog.show('Se esta tramitando la operación...');
+            return true;
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/PaymentSuite/PaylandsBundle/Resources/views/Paylands/scripts.html.twig
+++ b/src/PaymentSuite/PaylandsBundle/Resources/views/Paylands/scripts.html.twig
@@ -1,0 +1,94 @@
+<script type="text/javascript" src="https://ws-paylands.paynopain.com/js/v1-iframe.js"></script>
+
+<script type="text/javascript">
+
+    window.addEventListener('paylandsLoaded', function(){
+
+        var CUSTOMER_TOKEN_FIELD = 'paylands_customerToken';
+        var VALIDATE_BUTTON = 'paylands_validate_button';
+        var CARD_CONTAINER = 'paylands_card';
+        var ERROR_CONTAINER = 'paylands_error';
+
+        paylandsForm = document.forms['paylands'];
+
+        paylandsForm.loadSavedCard = function(card){
+            var fields = this.elements;
+
+            for( var i in card){
+                var selector = '[data-source="' + i + '"]';
+                var field = this.querySelector(selector);
+
+                if(field !== null){
+                    field.value = card[i];
+                }
+            }
+        };
+
+        paylandsForm.setOnlyTokenization = function(val){
+            this.elements['paylands_onlyTokenizeCard'].value = !!val ? 1 : 0;
+        };
+
+        paylandsForm.enablePayment = function(){
+            this.setOnlyTokenization(false);
+        };
+
+        paylandsForm.disablePayment = function(){
+            this.setOnlyTokenization(true);
+        };
+
+        var errors = document.getElementById(ERROR_CONTAINER);
+
+        errors.clear = function(){
+            this.innerHTML = '';
+        };
+
+        errors.addError = function(error){
+            this.innerHTML += error.outerHTML;
+        };
+
+        /**
+         * SDK Listeners.
+         */
+        window.addEventListener('initiated', function(){
+            var validate = document.getElementById(VALIDATE_BUTTON);
+
+            validate.addEventListener('click', function (ev) {
+                errors.clear();
+                paylands.storeSourceCard(true, '{{ service }}');
+            });
+
+            window.addEventListener('savedCard', function (ev) {
+                paylandsForm.loadSavedCard(ev.data.source);
+                paylandsForm.submit();
+            });
+
+            window.addEventListener('error', function (ev) {
+                if(typeof ev.data === 'undefined'){
+                    return;
+                }
+
+                var foundErrors = ev.data.errors || [];
+
+                for(var i = 0; i < foundErrors.length; i++){
+                    errors.addError(document.getElementById(foundErrors[i]));
+                }
+            });
+
+            window.addEventListener('errorServer', function (ev) {
+                errors.addError(document.getElementById('cardServer'));
+            });
+        });
+
+        /**
+         * Initialization.
+         */
+        var token = document.getElementById(CUSTOMER_TOKEN_FIELD).value;
+
+        paylands.setMode('{{ sandbox ? 'sandbox' : 'prod' }}');
+        paylands.setTemplate('{{ template }}');
+        paylands.setAdditional('{{ additional }}');
+
+        paylands.initializate(token, CARD_CONTAINER);
+    });
+
+</script>

--- a/src/PaymentSuite/PaylandsBundle/Resources/views/Paylands/view.html.twig
+++ b/src/PaymentSuite/PaylandsBundle/Resources/views/Paylands/view.html.twig
@@ -1,0 +1,14 @@
+<div id="paylands_card"></div>
+
+<div style="display: none;">
+    <span id="cardPan" class="error">{{ 'paylands.error.cardPan'|trans({}, 'PaylandsBundle') }}</span>
+    <span id="cardCode" class="error">{{ 'paylands.error.cardCode'|trans({}, 'PaylandsBundle') }}</span>
+    <span id="cardExpiryDate" class="error">{{ 'paylands.error.cardExpiryDate'|trans({}, 'PaylandsBundle') }}</span>
+    <span id="cardServer" class="error">{{ 'paylands.error.cardServer'|trans({}, 'PaylandsBundle') }}</span>
+</div>
+
+<div id="paylands_form">
+    {{ form(paylands_form) }}
+</div>
+
+<div id="paylands_error"></div>

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsCurrencyServiceResolver.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsCurrencyServiceResolver.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Services;
+
+use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+
+/**
+ * Class PaylandsCurrencyServiceResolver.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsCurrencyServiceResolver
+{
+    /**
+     * UUIDs of the services to pay through by currency.
+     *
+     * @var array
+     */
+    protected $services;
+
+    /**
+     * UUID of the service to validate card against.
+     *
+     * @var string
+     */
+    protected $validationService;
+
+    /**
+     * @var PaymentBridgeInterface
+     */
+    protected $paymentBridge;
+
+    /**
+     * PaylandsCurrencyServiceResolver constructor.
+     *
+     * @param PaymentBridgeInterface $paymentBridge
+     */
+    public function __construct(PaymentBridgeInterface $paymentBridge)
+    {
+        $this->paymentBridge = $paymentBridge;
+
+        $this->services = [];
+    }
+
+    /**
+     * Adds a new service ID for a given currency ISO code.
+     *
+     * @param $currency
+     * @param $service
+     *
+     * @return $this Self instance
+     */
+    public function addService($currency, $service)
+    {
+        $this->services[$currency] = $service;
+
+        return $this;
+    }
+
+    /**
+     * Gets the available service ID for currency indicated by PaymentBridge.
+     *
+     * @return string Service ID for the currency
+     */
+    public function getService()
+    {
+        $currency = $this->paymentBridge->getCurrency();
+
+        if (key_exists($currency, $this->services)) {
+            return $this->services[$currency];
+        }
+
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getValidationService()
+    {
+        if (!is_null($this->validationService)) {
+            return $this->validationService;
+        }
+
+        return $this->getService();
+    }
+
+    /**
+     * @param string $validationService
+     *
+     * @return PaylandsCurrencyServiceResolver $this
+     */
+    public function setValidationService($validationService = null)
+    {
+        $this->validationService = $validationService;
+
+        return $this;
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsFormFactory.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsFormFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Services;
+
+use PaymentSuite\PaylandsBundle\Exception\CreateFormException;
+use PaymentSuite\PaylandsBundle\Form\Type\PaylandsType;
+use PaymentSuite\PaylandsBundle\PaylandsMethod;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Class PaylandsFormFactory.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsFormFactory
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * PaylandsFormFactory constructor.
+     *
+     * @param FormFactoryInterface  $formFactory
+     * @param UrlGeneratorInterface $urlGenerator
+     */
+    public function __construct(FormFactoryInterface $formFactory, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->formFactory = $formFactory;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * Creates the payment form.
+     *
+     * @param mixed $data
+     * @param array $options
+     *
+     * @return FormInterface
+     *
+     * @throws CreateFormException
+     */
+    public function create($data = null, array $options = [])
+    {
+        $options = array_merge($options, [
+            'action' => $this->urlGenerator->generate('paymentsuite_paylands_execute'),
+            'method' => 'POST',
+        ]);
+
+        if (is_array($data)) {
+            $data = $this
+                ->formFactory
+                ->create(PaylandsType::class)
+                ->submit($data, true)
+                ->getData();
+        }
+
+        if (is_null($data) || $data instanceof PaylandsMethod) {
+            return $this->formFactory->create(PaylandsType::class, $data, $options);
+        }
+
+        throw new CreateFormException();
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsManager.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsManager.php
@@ -1,0 +1,243 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Services;
+
+use PaymentSuite\PaylandsBundle\Exception\CardNotFoundException;
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentOrderNotFoundException;
+use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+use PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher;
+use PaymentSuite\PaylandsBundle\PaylandsMethod;
+use WAM\Paylands\ClientInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class PaylandsManager.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsManager
+{
+    const STATUS_OK = 'OK';
+
+    const STATUS_KO = 'KO';
+
+    /**
+     * @var PaymentBridgeInterface
+     *
+     * Payment Bridge
+     */
+    private $paymentBridge;
+
+    /**
+     * @var PaymentEventDispatcher
+     *
+     * Payment event dispatcher
+     */
+    private $paymentEventDispatcher;
+
+    /**
+     * @var ClientInterface
+     *
+     * Paylands API client
+     */
+    private $apiClient;
+
+    /**
+     * @var RequestStack
+     *
+     * Http request stack
+     */
+    private $requestStack;
+
+    /**
+     * @var PaylandsCurrencyServiceResolver
+     */
+    private $currencyServiceResolver;
+
+    /**
+     * PaylandsManager constructor.
+     *
+     * @param PaymentBridgeInterface          $paymentBridge
+     * @param PaymentEventDispatcher          $paymentEventDispatcher
+     * @param ClientInterface                 $apiClient
+     * @param RequestStack                    $requestStack
+     * @param PaylandsCurrencyServiceResolver $currencyServiceResolver
+     */
+    public function __construct(
+        PaymentBridgeInterface $paymentBridge,
+        PaymentEventDispatcher $paymentEventDispatcher,
+        ClientInterface $apiClient,
+        RequestStack $requestStack,
+        PaylandsCurrencyServiceResolver $currencyServiceResolver
+    ) {
+        $this->paymentBridge = $paymentBridge;
+        $this->paymentEventDispatcher = $paymentEventDispatcher;
+        $this->apiClient = $apiClient;
+        $this->requestStack = $requestStack;
+        $this->currencyServiceResolver = $currencyServiceResolver;
+    }
+
+    /**
+     * Tries to process a payment through Paylands.
+     *
+     * @param PaylandsMethod $paymentMethod Payment method
+     *
+     * @return PaylandsManager Self object
+     *
+     * @throws PaymentException
+     */
+    public function processPayment(PaylandsMethod $paymentMethod)
+    {
+        /*
+         * At this point, order must be created given a cart, and placed in PaymentBridge.
+         *
+         * So, $this->paymentBridge->getOrder() must return an object
+         */
+        $this
+            ->paymentEventDispatcher
+            ->notifyPaymentOrderLoad(
+                $this->paymentBridge,
+                $paymentMethod
+            );
+
+        /*
+         * Order Not found Exception must be thrown just here.
+         */
+        if (!$this->paymentBridge->getOrder()) {
+            throw new PaymentOrderNotFoundException();
+        }
+
+        /*
+         * Order exists right here.
+         */
+        $this
+            ->paymentEventDispatcher
+            ->notifyPaymentOrderCreated(
+                $this->paymentBridge,
+                $paymentMethod
+            );
+
+        /*
+         * Try to make the payment transaction
+         */
+        try {
+            $this->validateCard($paymentMethod);
+
+            if (!$paymentMethod->isOnlyTokenizeCard()) {
+                $this->createTransaction($paymentMethod);
+            }
+
+            /*
+             * Payment paid done.
+             *
+             * Paid process has ended ( No matters result )
+             */
+            $this
+                ->paymentEventDispatcher
+                ->notifyPaymentOrderDone(
+                    $this->paymentBridge,
+                    $paymentMethod
+                );
+
+            if (self::STATUS_OK !== $paymentMethod->getPaymentStatus()) {
+                throw new PaymentException(sprintf('Order %s could not be paid',
+                    $paymentMethod->getPaymentResult()['order']['uuid']
+                ));
+            }
+
+            /*
+             * Payment paid successfully.
+             *
+             * Paid process has ended successfully
+             */
+            $this
+                ->paymentEventDispatcher
+                ->notifyPaymentOrderSuccess(
+                    $this->paymentBridge,
+                    $paymentMethod
+                );
+        } catch (PaymentException $e) {
+            /*
+             * Payment paid failed.
+             *
+             * Paid process has ended failed
+             */
+            $this
+                ->paymentEventDispatcher
+                ->notifyPaymentOrderFail(
+                    $this->paymentBridge,
+                    $paymentMethod
+                );
+
+            throw $e;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sends the payment order to Paylands.
+     *
+     * @param PaylandsMethod $paymentMethod
+     */
+    private function createTransaction(PaylandsMethod $paymentMethod)
+    {
+        $paymentOrder = $this->apiClient->createPayment(
+            $paymentMethod->getCustomerExternalId(),
+            $this->paymentBridge->getAmount(),
+            (string) $this->paymentBridge->getOrder(),
+            $this->currencyServiceResolver->getService()
+        );
+
+        $transaction = $this->apiClient->directPayment(
+            $this->requestStack->getMasterRequest()->getClientIp(),
+            $paymentOrder['order']['uuid'],
+            $paymentMethod->getCardUuid()
+        );
+
+        $paymentMethod
+            ->setPaymentStatus($transaction['order']['paid'] ? self::STATUS_OK : self::STATUS_KO)
+            ->setPaymentResult($transaction);
+    }
+
+    /**
+     * Validates against Paylands that the card is associates with customer.
+     *
+     * @param PaylandsMethod $paymentMethod
+     *
+     * @throws CardNotFoundException
+     */
+    private function validateCard(PaylandsMethod $paymentMethod)
+    {
+        $response = $this->apiClient->retrieveCustomerCards($paymentMethod->getCustomerExternalId());
+
+        foreach ($response['cards'] as $card) {
+            if ($paymentMethod->getCardUuid() == $card['uuid']) {
+                $paymentMethod
+                    ->setPaymentStatus(self::STATUS_OK)
+                    ->setPaymentResult($response);
+
+                return;
+            }
+        }
+
+        throw new CardNotFoundException(sprintf('Card %s not found for customer %s',
+            $paymentMethod->getCardUuid(),
+            $paymentMethod->getCustomerExternalId()
+        ));
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsViewRenderer.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsViewRenderer.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Services;
+
+use WAM\Paylands\ClientInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class PaylandsViewRenderer.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsViewRenderer
+{
+    /**
+     * @var ClientInterface
+     */
+    protected $apiClient;
+
+    /**
+     * @var PaylandsFormFactory
+     */
+    protected $paymentFormFactory;
+
+    /**
+     * @var PaylandsCurrencyServiceResolver
+     */
+    protected $currencyServiceResolver;
+
+    /**
+     * @var string
+     */
+    protected $viewTemplate;
+
+    /**
+     * @var string
+     */
+    protected $scriptsTemplate;
+
+    /**
+     * PaylandsViewRenderer constructor.
+     *
+     * @param ClientInterface                 $apiClient
+     * @param PaylandsFormFactory             $paymentFormFactory
+     * @param PaylandsCurrencyServiceResolver $currencyServiceResolver
+     * @param string                          $viewTemplate
+     * @param string                          $scriptsTemplate
+     */
+    public function __construct(
+        ClientInterface $apiClient,
+        PaylandsFormFactory $paymentFormFactory,
+        PaylandsCurrencyServiceResolver $currencyServiceResolver,
+        $viewTemplate,
+        $scriptsTemplate
+    ) {
+        $this->apiClient = $apiClient;
+        $this->paymentFormFactory = $paymentFormFactory;
+        $this->currencyServiceResolver = $currencyServiceResolver;
+        $this->viewTemplate = $viewTemplate;
+        $this->scriptsTemplate = $scriptsTemplate;
+    }
+
+    /**
+     * @param \Twig_Environment $environment
+     * @param array             $options
+     *
+     * @return string
+     */
+    public function renderView(\Twig_Environment $environment, array $options = array())
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+
+        $options = $resolver->resolve($options);
+
+        $response = $this->apiClient->createCustomer($options['customer_ext_id']);
+
+        $form = $this->paymentFormFactory->create([
+            'customerExternalId' => $options['customer_ext_id'],
+            'customerToken' => $response['Customer']['token'],
+            'onlyTokenizeCard' => (int) $options['only_tokenize_card'],
+        ]);
+
+        $renderedView = $environment->render($options['template'] ?: $this->viewTemplate, [
+            'paylands_form' => $form->createView(),
+        ]);
+
+        $renderedScripts = $environment->render($this->scriptsTemplate, [
+            'sandbox' => $this->apiClient->isModeSandboxEnabled(),
+            'service' => $this->currencyServiceResolver->getValidationService(),
+            'template' => $this->apiClient->getTemplate($options['locale']),
+            'additional' => $options['additional'],
+        ]);
+
+        return $renderedView.$renderedScripts;
+    }
+
+    /**
+     * Set default renderer configuration.
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'customer_ext_id' => uniqid(),
+            'only_tokenize_card' => false,
+            'additional' => '',
+            'template' => null,
+            'locale' => null,
+        ]);
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Tests\DependencyInjection;
+
+use WAM\Paylands\ClientInterface;
+use PaymentSuite\PaylandsBundle\DependencyInjection\Configuration;
+
+/**
+ * Class ConfigurationTest.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var array
+     */
+    public $defaults;
+
+    /**
+     * @var array
+     */
+    public $mandatory;
+
+    /**
+     * @test
+     * @dataProvider dataTestConfiguration
+     *
+     * @param mixed $inputConfig
+     * @param mixed $expectedConfig
+     */
+    public function testConfiguration($inputConfig, $expectedConfig)
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    public function dataTestConfiguration()
+    {
+        $input1 = $this->getMandatoryConfiguration();
+        $expectations1 = array_merge($this->getDefaultConfiguration(), $this->getMandatoryConfiguration());
+
+        $i18nTemplates = [
+            'i18n_template_uuids' => [
+            'es' => 'es-uuid',
+            'fr' => 'fr-uuid',
+            'pt' => 'pt-uuid',
+            ],
+        ];
+
+        $input2 = array_merge($input1, $i18nTemplates);
+        $expectations2 = array_merge($expectations1, $i18nTemplates);
+
+        return [
+            'test default configuration' => [
+                $input1, $expectations1,
+            ],
+            'test i18n templates configuration' => [
+                $input2, $expectations2,
+            ],
+        ];
+    }
+
+    protected function getDefaultConfiguration()
+    {
+        return [
+            'operative' => ClientInterface::OPERATIVE_AUTHORIZATION,
+            'fallback_template_uuid' => 'default',
+            'i18n_template_uuids' => [],
+            'url' => 'https://ws-paylands.paynopain.com/v1/',
+            'url_sandbox' => 'https://ws-paylands.paynopain.com/v1/sandbox/',
+            'sandbox' => false,
+            'templates' => [
+                'view' => 'PaylandsBundle:Paylands:view.html.twig',
+                'scripts' => 'PaylandsBundle:Paylands:scripts.html.twig',
+            ],
+            'interfaces' => [
+                'http_client' => null,
+                'request_factory' => null,
+                'uri_factory' => null,
+            ],
+            'api_client' => Configuration::API_CLIENT_DEFAULT,
+            'validation_service' => null,
+        ];
+    }
+
+    protected function getMandatoryConfiguration()
+    {
+        return [
+            'api_key' => 'test-key',
+            'signature' => 'test-signature',
+            'services' => [
+                ['currency' => 'EUR', 'service' => 'test-service'],
+            ],
+            'payment_success' => [
+                'route' => 'test-route-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+            'payment_failure' => [
+                'route' => 'test-route-failure',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsCurrencyServiceResolverTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsCurrencyServiceResolverTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Tests\Services;
+
+use PaymentSuite\PaylandsBundle\Services\PaylandsCurrencyServiceResolver;
+use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+
+/**
+ * Class PaylandsCurrencyServiceResolverTest.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsCurrencyServiceResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function addServiceWorks()
+    {
+        $resolver = new PaylandsCurrencyServiceResolverTestClass($this->getPaymentBridgeMock('EUR')->reveal());
+
+        /*
+         * Fresh resolve has no service registered
+         */
+        $this->assertEmpty($resolver->getServices());
+
+        /*
+         * Can add a new service
+         */
+        $resolver->addService('EUR', 'eur-service-id');
+
+        $this->assertNotEmpty($resolver->getServices());
+        $this->assertCount(1, $resolver->getServices());
+        $this->assertArrayHasKey('EUR', $resolver->getServices());
+        $this->assertEquals('eur-service-id', $resolver->getServices()['EUR']);
+
+        /*
+         * Can add more than one service
+         */
+        $resolver->addService('USD', 'usd-service-id');
+
+        $this->assertNotEmpty($resolver->getServices());
+        $this->assertCount(2, $resolver->getServices());
+        $this->assertArrayHasKey('EUR', $resolver->getServices());
+        $this->assertArrayHasKey('USD', $resolver->getServices());
+        $this->assertEquals('eur-service-id', $resolver->getServices()['EUR']);
+        $this->assertEquals('usd-service-id', $resolver->getServices()['USD']);
+
+        /*
+         * Overwrites a service if same key is used
+         */
+        $resolver->addService('USD', 'usd-service-id-2');
+
+        $this->assertNotEmpty($resolver->getServices());
+        $this->assertCount(2, $resolver->getServices());
+        $this->assertArrayHasKey('EUR', $resolver->getServices());
+        $this->assertArrayHasKey('USD', $resolver->getServices());
+        $this->assertEquals('eur-service-id', $resolver->getServices()['EUR']);
+        $this->assertEquals('usd-service-id-2', $resolver->getServices()['USD']);
+
+        return $resolver;
+    }
+
+    /**
+     * @test
+     * @depends addServiceWorks
+     */
+    public function getServiceWorks(PaylandsCurrencyServiceResolverTestClass $resolver)
+    {
+        $this->assertEquals('eur-service-id', $resolver->getService());
+
+        $resolver->setPaymentBridge($this->getPaymentBridgeMock('USD')->reveal());
+
+        $this->assertEquals('usd-service-id-2', $resolver->getService());
+
+        $resolver->setPaymentBridge($this->getPaymentBridgeMock('GBP')->reveal());
+
+        $this->assertEquals('', $resolver->getService());
+    }
+
+    /**
+     * Returns a PaymentBridgeInterface mock.
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    private function getPaymentBridgeMock($currencyIso)
+    {
+        $bridge = $this->prophesize(PaymentBridgeInterface::class);
+        $bridge
+            ->getCurrency()
+            ->willReturn($currencyIso);
+
+        return $bridge;
+    }
+}
+
+/**
+ * Class ExposedApiServiceResolver.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsCurrencyServiceResolverTestClass extends PaylandsCurrencyServiceResolver
+{
+    /**
+     * @return array Services registered at the moment
+     */
+    public function getServices()
+    {
+        return $this->services;
+    }
+
+    /**
+     * Inyects new PaymentBridgeInterface to use.
+     *
+     * @param PaymentBridgeInterface $paymentBridge
+     */
+    public function setPaymentBridge(PaymentBridgeInterface $paymentBridge)
+    {
+        $this->paymentBridge = $paymentBridge;
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Twig/PaylandsExtension.php
+++ b/src/PaymentSuite/PaylandsBundle/Twig/PaylandsExtension.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the PaymentSuite package.
+ *
+ * Copyright (c) 2013-2016 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace PaymentSuite\PaylandsBundle\Twig;
+
+use PaymentSuite\PaylandsBundle\Services\PaylandsViewRenderer;
+
+/**
+ * Class PaylandsExtension.
+ *
+ * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ */
+class PaylandsExtension extends \Twig_Extension
+{
+    /**
+     * @var PaylandsViewRenderer
+     */
+    protected $viewRenderer;
+
+    /**
+     * PaylandsExtension constructor.
+     *
+     * @param PaylandsViewRenderer $viewRenderer
+     */
+    public function __construct(PaylandsViewRenderer $viewRenderer)
+    {
+        $this->viewRenderer = $viewRenderer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('paylands_view', [
+                $this->viewRenderer,
+                'renderView',
+            ], [
+                'needs_environment' => true,
+                'is_safe' => ['html'],
+            ]),
+        ];
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/composer.json
+++ b/src/PaymentSuite/PaylandsBundle/composer.json
@@ -1,0 +1,41 @@
+{
+    "name": "paymentsuite/paylands-bundle",
+    "type": "symfony-bundle",
+    "description": "Paylands PaymentSuite Component",
+    "keywords": ["paylands", "cards", "payment", "ecommerce"],
+    "license": "MIT",
+    "support": {
+        "email": "sgarcia@wearemarketing.com"
+    },
+    "authors": [
+        {
+            "name": "Santiago Garcia",
+            "email": "sgarcia@wearemarketing.com"
+        }
+    ],
+    "require": {
+        "php": "^5.5|^7.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/form": "^2.8|^3.0",
+        "symfony/config": "^2.8|^3.0",
+        "symfony/http-kernel": "^2.8|^3.0",
+        "symfony/http-foundation": "^2.8|^3.0",
+        "symfony/dependency-injection": "^2.8|^3.0",
+        "symfony/options-resolver": "^2.8|^3.0",
+        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "twig/twig": "^1.23.1",
+        "paymentsuite/payment-core-bundle": "^2.0",
+        "wearemarketing/paylands-php": "dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.19"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "Implements a required PSR-7 Http client"
+    },
+    "autoload": {
+        "psr-4": {
+            "PaymentSuite\\PaylandsBundle\\": ""
+        }
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/phpunit.xml.dist
+++ b/src/PaymentSuite/PaylandsBundle/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="PaylandsBundle Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources/</directory>
+                <directory>./DependencyInjection/</directory>
+                <directory>./vendor/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
We have added the following features:

- Upper to PHP 5.5 to allow *::class* for all repo and for Paylands Bundle. The rest of bundle is still on php 5.4 the minimum version
- Remove support for hhvm
- We support Symfony 2.8, but we have a BC. If you want to use this library with <2.8 use 2.0 branch.
- Add support for Paylands Gateway (pay no pain company)