### PR TITLE
Feature/upgrade lib

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -1,3 +1,0 @@
-split:
-    # Split definition for http://gitsplit.com
-    src/PaymentSuite/*: git@github.com:PaymentSuite/$i.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 Paymentsuite is a suite of payment Bundles built on top of Symfony and under
 [MIT](http://opensource.org/licenses/MIT) license.
 
+### Important
+
+This branch intended use is for symfony 3.4 and php 7.1
+
 ### Tags
 
 * Use last unstable version ( alias of `dev-master` ) to stay always in last 

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
-        "symfony/finder": "^2.8|^3.0",
-        "symfony/config": "^2.8|^3.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
-        "symfony/form": "^2.8|^3.0",
-        "symfony/http-kernel": "^2.8|^3.0",
-        "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/options-resolver": "^2.8|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "php": "^7.1",
+        "symfony/finder": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/options-resolver": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
         "psr/log": "^1.0",
         "twig/twig": "^1.23.1",
         "stripe/stripe-php": "3.4.0",
@@ -38,10 +38,9 @@
     },
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
-        "elcodi/fixtures-booster-bundle": "^2.0",
         "mmoreram/php-formatter": "1.1.0",
-        "fabpot/php-cs-fixer": "1.11",
-        "phpunit/phpunit": "<6.0"
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "phpunit/phpunit": "^7.0"
     },
     "replace": {
         "paymentsuite/bankwire-bundle": "self.version",

--- a/src/PaymentSuite/BankwireBundle/BankwireBundle.php
+++ b/src/PaymentSuite/BankwireBundle/BankwireBundle.php
@@ -44,7 +44,7 @@ class BankwireBundle extends Bundle implements DependentBundleInterface
      *
      * @return array Bundle instances
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel): array
     {
         return [
             'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',

--- a/src/PaymentSuite/BankwireBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/BankwireBundle/Resources/config/controllers.yml
@@ -6,7 +6,7 @@ services:
     paymentsuite.bankwire.payment_controller:
         class: PaymentSuite\BankwireBundle\Controller\PaymentController
         arguments:
-            - "@paymentsuite.bankwire.manager"
-            - "@paymentsuite.bankwire.route_success"
-            - "@paymentsuite.bridge"
-            - "@router"
+            - @paymentsuite.bankwire.manager'
+            - @paymentsuite.bankwire.route_success'
+            - @paymentsuite.bridge'
+            - @router'

--- a/src/PaymentSuite/BankwireBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/BankwireBundle/Resources/config/services.yml
@@ -9,6 +9,6 @@ services:
     paymentsuite.bankwire.manager:
         class: PaymentSuite\BankwireBundle\Services\BankwireManager
         arguments:
-            - "@paymentsuite.bankwire.method_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.bankwire.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'

--- a/src/PaymentSuite/BankwireBundle/composer.json
+++ b/src/PaymentSuite/BankwireBundle/composer.json
@@ -21,21 +21,21 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.1",
 
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
 
         "paymentsuite/payment-core-bundle": "^2.0"
     },
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/PaymentSuite/FreePaymentBundle/FreePaymentBundle.php
+++ b/src/PaymentSuite/FreePaymentBundle/FreePaymentBundle.php
@@ -44,7 +44,7 @@ class FreePaymentBundle extends Bundle implements DependentBundleInterface
      *
      * @return array Bundle instances
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel): array
     {
         return [
             'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',

--- a/src/PaymentSuite/FreePaymentBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/FreePaymentBundle/Resources/config/controllers.yml
@@ -6,7 +6,7 @@ services:
     paymentsuite.freepayment.payment_controller:
         class: PaymentSuite\FreePaymentBundle\Controller\PaymentController
         arguments:
-            - "@paymentsuite.freepayment.manager"
-            - "@paymentsuite.freepayment.route_success"
-            - "@paymentsuite.bridge"
-            - "@router"
+            - '@paymentsuite.freepayment.manager'
+            - '@paymentsuite.freepayment.route_success'
+            - '@paymentsuite.bridge'
+            - '@router'

--- a/src/PaymentSuite/FreePaymentBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/FreePaymentBundle/Resources/config/services.yml
@@ -9,6 +9,6 @@ services:
     paymentsuite.freepayment.manager:
         class: PaymentSuite\FreePaymentBundle\Services\FreePaymentManager
         arguments:
-            - "@paymentsuite.freepayment.method_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.freepayment.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'

--- a/src/PaymentSuite/FreePaymentBundle/composer.json
+++ b/src/PaymentSuite/FreePaymentBundle/composer.json
@@ -21,21 +21,21 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.1",
 
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
 
         "paymentsuite/payment-core-bundle": "^2.0"
     },
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/PaylandsBundle.php
+++ b/src/PaymentSuite/PaylandsBundle/PaylandsBundle.php
@@ -38,7 +38,7 @@ class PaylandsBundle extends Bundle implements DependentBundleInterface
     /**
      * {@inheritdoc}
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel): array
     {
         return [
             'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',

--- a/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -15,6 +15,7 @@
 
 namespace PaymentSuite\PaylandsBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use WAM\Paylands\ClientInterface;
 use PaymentSuite\PaylandsBundle\DependencyInjection\Configuration;
 
@@ -23,7 +24,7 @@ use PaymentSuite\PaylandsBundle\DependencyInjection\Configuration;
  *
  * @author WAM Team <develop@wearemarketing.com>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * @var array

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsCurrencyServiceResolverTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsCurrencyServiceResolverTest.php
@@ -17,13 +17,14 @@ namespace PaymentSuite\PaylandsBundle\Tests\Services;
 
 use PaymentSuite\PaylandsBundle\Services\PaylandsCurrencyServiceResolver;
 use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaylandsCurrencyServiceResolverTest.
  *
  * @author WAM Team <develop@wearemarketing.com>
  */
-class PaylandsCurrencyServiceResolverTest extends \PHPUnit_Framework_TestCase
+class PaylandsCurrencyServiceResolverTest extends TestCase
 {
     /**
      * @test

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsEventDispatcherTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsEventDispatcherTest.php
@@ -18,6 +18,7 @@ namespace PaymentSuite\PaylandsBundle\Tests\Services;
 use PaymentSuite\PaylandsBundle\Event\PaylandsCardValidEvent;
 use PaymentSuite\PaylandsBundle\PaylandsMethod;
 use PaymentSuite\PaylandsBundle\Services\PaylandsEventDispatcher;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -27,7 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * @author WAM Team <develop@wearemarketing.com>
  */
-class PaylandsEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class PaylandsEventDispatcherTest extends TestCase
 {
     /**
      * @test

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsManagerTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsManagerTest.php
@@ -24,13 +24,14 @@ use PaymentSuite\PaylandsBundle\Services\PaylandsManager;
 use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
 use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
 use PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PaylandsManagerTest
  *
  * @author WAM Team <develop@wearemarketing.com>
  */
-class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
+class PaylandsManagerTest extends TestCase
 {
     /**
      * @test
@@ -322,14 +323,5 @@ class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
         $this->expectException(PaymentException::class);
 
         $paylandsManager->processPayment($paymentMethod);
-    }
-
-    public function expectException($exception)
-    {
-        if (method_exists('\PHPUnit_Framework_TestCase', 'expectException')) {
-            parent::expectException($exception);
-        }
-
-        parent::setExpectedException($exception);
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/composer.json
+++ b/src/PaymentSuite/PaylandsBundle/composer.json
@@ -14,21 +14,21 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
-        "symfony/form": "^2.8|^3.0",
-        "symfony/config": "^2.8|^3.0",
-        "symfony/http-kernel": "^2.8|^3.0",
-        "symfony/http-foundation": "^2.8|^3.0",
-        "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/options-resolver": "^2.8|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "php": "^7.1",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/http-foundation": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/options-resolver": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
         "twig/twig": "^1.23.1",
         "paymentsuite/payment-core-bundle": "^2.0",
         "wearemarketing/paylands-php": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "Implements a required PSR-7 Http client"

--- a/src/PaymentSuite/PaymentCoreBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/PaymentCoreBundle/Resources/config/services.yml
@@ -3,12 +3,12 @@ services:
     paymentsuite.event_dispatcher:
         class: PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher
         arguments:
-            - "@event_dispatcher"
+            - '@event_dispatcher'
 
     paymentsuite.logger:
         class: PaymentSuite\PaymentCoreBundle\Services\PaymentLogger
         arguments:
-            - "@logger"
-            - %paymentsuite.logger%
+            - '@logger'
+            - '%paymentsuite.logger%'
         tags:
             - { name: monolog.logger, channel: 'paymentsuite' }

--- a/src/PaymentSuite/PaymentCoreBundle/Tests/Services/PaymentEventDispatcherTest.php
+++ b/src/PaymentSuite/PaymentCoreBundle/Tests/Services/PaymentEventDispatcherTest.php
@@ -15,6 +15,7 @@
 
 namespace PaymentSuite\PaymentCoreBundle\Tests\Services;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 use PaymentSuite\PaymentCoreBundle\PaymentCoreEvents;
@@ -25,7 +26,7 @@ use PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher;
 /**
  * Tests PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher class.
  */
-class PaymentEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class PaymentEventDispatcherTest extends TestCase
 {
     /**
      * @var PaymentBridgeInterface
@@ -58,8 +59,8 @@ class PaymentEventDispatcherTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->paymentBridge = $this->getMock('\PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface');
-        $this->paymentMethod = $this->getMock('\PaymentSuite\PaymentCoreBundle\PaymentMethodInterface');
+        $this->paymentBridge = $this->getMockBuilder('\PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface')->getMock();
+        $this->paymentMethod = $this->getMockBuilder('\PaymentSuite\PaymentCoreBundle\PaymentMethodInterface')->getMock();
     }
 
     /**

--- a/src/PaymentSuite/PaymentCoreBundle/Tests/Services/PaymentLoggerTest.php
+++ b/src/PaymentSuite/PaymentCoreBundle/Tests/Services/PaymentLoggerTest.php
@@ -16,11 +16,12 @@
 namespace PaymentSuite\PaymentCoreBundle\Tests\Services;
 
 use PaymentSuite\PaymentCoreBundle\Services\PaymentLogger;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests PaymentSuite\PaymentCoreBundle\Services\PaymentLogger class.
  */
-class PaymentLoggerTest extends \PHPUnit_Framework_TestCase
+class PaymentLoggerTest extends TestCase
 {
     /**
      * Tests log().

--- a/src/PaymentSuite/PaymentCoreBundle/composer.json
+++ b/src/PaymentSuite/PaymentCoreBundle/composer.json
@@ -21,19 +21,19 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.1",
 
-        "symfony/event-dispatcher": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
+        "symfony/event-dispatcher": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/dependency-injection": "^3.4",
 
         "psr/log": "~1.0"
     },
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/PaypalWebCheckoutBundle.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/PaypalWebCheckoutBundle.php
@@ -44,7 +44,7 @@ class PaypalWebCheckoutBundle extends Bundle implements DependentBundleInterface
      *
      * @return array Bundle instances
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel): array
     {
         return [
             'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Resources/config/controllers.yml
@@ -6,11 +6,11 @@ services:
     paymentsuite.paypal_web_checkout.payment_controller:
         class: PaymentSuite\PaypalWebCheckoutBundle\Controller\PaymentController
         arguments:
-            - "@paymentsuite.paypal_web_checkout.manager"
-            - "@templating"
+            - '@paymentsuite.paypal_web_checkout.manager'
+            - '@templating'
 
     paymentsuite.paypal_web_checkout.process_controller:
         class: PaymentSuite\PaypalWebCheckoutBundle\Controller\ProcessController
         arguments:
-            - "@paymentsuite.paypal_web_checkout.manager"
-            - "@paymentsuite.logger"
+            - '@paymentsuite.paypal_web_checkout.manager'
+            - '@paymentsuite.logger'

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Resources/config/services.yml
@@ -6,26 +6,26 @@ services:
     paymentsuite.paypal_web_checkout.form_type_factory:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutFormTypeFactory
         arguments:
-            - "@paymentsuite.paypal_web_checkout.url_factory"
-            - "@paymentsuite.bridge"
-            - "@form.factory"
-            - %paymentsuite.paypal_web_checkout.business%
+            - '@paymentsuite.paypal_web_checkout.url_factory'
+            - '@paymentsuite.bridge'
+            - '@form.factory'
+            - '%paymentsuite.paypal_web_checkout.business%'
 
     paymentsuite.paypal_web_checkout.manager:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutManager
         arguments:
-            - "@paymentsuite.paypal_web_checkout.url_factory"
-            - "@paymentsuite.paypal_web_checkout.form_type_factory"
-            - "@paymentsuite.paypal_web_checkout.method_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.paypal_web_checkout.url_factory'
+            - '@paymentsuite.paypal_web_checkout.form_type_factory'
+            - '@paymentsuite.paypal_web_checkout.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
 
     paymentsuite.paypal_web_checkout.url_factory:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutUrlFactory
         arguments:
-            - "@paymentsuite.paypal_web_checkout.routes"
-            - "@router"
-            - %paymentsuite.paypal_web_checkout.api_endpoint%
+            - '@paymentsuite.paypal_web_checkout.routes'
+            - '@router'
+            - '%paymentsuite.paypal_web_checkout.api_endpoint%'
 
     paymentsuite.paypal_web_checkout.method_factory:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutMethodFactory

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/composer.json
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.1",
 
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/http-foundation": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/http-foundation": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
         "twig/twig": "^1.23.1",
 
         "paymentsuite/payment-core-bundle": "~1.1"
@@ -37,7 +37,7 @@
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/PaymentSuite/RedsysBundle/RedsysBundle.php
+++ b/src/PaymentSuite/RedsysBundle/RedsysBundle.php
@@ -44,7 +44,7 @@ class RedsysBundle extends Bundle implements DependentBundleInterface
      *
      * @return array Bundle instances
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel): array
     {
         return [
             'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',

--- a/src/PaymentSuite/RedsysBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/RedsysBundle/Resources/config/controllers.yml
@@ -6,19 +6,19 @@ services:
     paymentsuite.redsys.payment_controller:
         class: PaymentSuite\RedsysBundle\Controller\PaymentController
         arguments:
-            - @paymentsuite.redsys.manager
-            - @templating
+            - '@paymentsuite.redsys.manager'
+            - '@templating'
 
     paymentsuite.redsys.response_controller:
         class: PaymentSuite\RedsysBundle\Controller\ResponseController
         arguments:
-            - @paymentsuite.redsys.routes
-            - @router
+            - '@paymentsuite.redsys.routes'
+            - '@router'
 
     paymentsuite.redsys.result_controller:
         class: PaymentSuite\RedsysBundle\Controller\ResultController
         arguments:
-            - @paymentsuite.redsys.manager
-            - @paymentsuite.redsys.routes
-            - @paymentsuite.bridge
-            - @router
+            - '@paymentsuite.redsys.manager'
+            - '@paymentsuite.redsys.routes'
+            - '@paymentsuite.bridge'
+            - '@router'

--- a/src/PaymentSuite/RedsysBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/RedsysBundle/Resources/config/services.yml
@@ -6,26 +6,26 @@ services:
     paymentsuite.redsys.manager:
         class: PaymentSuite\RedsysBundle\Services\RedsysManager
         arguments:
-            - @paymentsuite.redsys.form_type_builder
-            - @paymentsuite.redsys.method_factory
-            - @paymentsuite.bridge
-            - @paymentsuite.event_dispatcher
-            - %paymentsuite.redsys.secret_key%
+            - '@paymentsuite.redsys.form_type_builder'
+            - '@paymentsuite.redsys.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
+            - '%paymentsuite.redsys.secret_key%'
 
     paymentsuite.redsys.form_type_builder:
         class: PaymentSuite\RedsysBundle\Services\RedsysFormTypeBuilder
         arguments:
-            - @paymentsuite.bridge
-            - @paymentsuite.redsys.url_factory
-            - @form.factory
-            - %paymentsuite.redsys.merchant_code%
-            - %paymentsuite.redsys.secret_key%
-            - %paymentsuite.redsys.url%
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.redsys.url_factory'
+            - '@form.factory'
+            - '%paymentsuite.redsys.merchant_code%'
+            - '%paymentsuite.redsys.secret_key%'
+            - '%paymentsuite.redsys.url%'
 
     paymentsuite.redsys.url_factory:
         class: PaymentSuite\RedsysBundle\Services\RedsysUrlFactory
         arguments:
-            - @router
+            - '@router'
 
     paymentsuite.redsys.method_factory:
         class: PaymentSuite\RedsysBundle\Services\RedsysMethodFactory

--- a/src/PaymentSuite/RedsysBundle/composer.json
+++ b/src/PaymentSuite/RedsysBundle/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.1",
 
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/http-foundation": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/http-foundation": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
         "twig/twig": "^1.23.1",
 
         "paymentsuite/payment-core-bundle": "^2.0"
@@ -37,7 +37,7 @@
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/PaymentSuite/StripeBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/StripeBundle/Resources/config/controllers.yml
@@ -6,9 +6,9 @@ services:
     paymentsuite.stripe.payment_controller:
         class: PaymentSuite\StripeBundle\Controller\PaymentController
         arguments:
-            - "@paymentsuite.stripe.manager"
-            - "@paymentsuite.stripe.method_factory"
-            - "@paymentsuite.stripe.routes"
-            - "@paymentsuite.bridge"
-            - "@router"
-            - "@form.factory"
+            - '@paymentsuite.stripe.manager'
+            - '@paymentsuite.stripe.method_factory'
+            - '@paymentsuite.stripe.routes'
+            - '@paymentsuite.bridge'
+            - '@router'
+            - '@form.factory'

--- a/src/PaymentSuite/StripeBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/StripeBundle/Resources/config/services.yml
@@ -2,21 +2,21 @@ services:
     paymentsuite.stripe.form_type:
         class: PaymentSuite\StripeBundle\Form\Type\StripeType
         arguments:
-            - "@paymentsuite.bridge"
+            - '@paymentsuite.bridge'
         tags:
             - { name: form.type, alias: stripe_view }
 
     paymentsuite.stripe.transaction_factory:
         class: PaymentSuite\StripeBundle\Services\StripeTransactionFactory
         arguments:
-            - "%paymentsuite.stripe.private_key%"
+            - '%paymentsuite.stripe.private_key%'
 
     paymentsuite.stripe.manager:
         class: PaymentSuite\StripeBundle\Services\StripeManager
         arguments:
-            - "@paymentsuite.stripe.transaction_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.stripe.transaction_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
 
     paymentsuite.stripe.method_factory:
         class: PaymentSuite\StripeBundle\Services\StripeMethodFactory
@@ -24,8 +24,8 @@ services:
     paymentsuite.stripe.template_render:
         class: PaymentSuite\StripeBundle\Services\StripeTemplateRender
         arguments:
-            - "@paymentsuite.bridge"
-            - "@form.factory"
-            - "%paymentsuite.stripe.public_key%"
-            - "%paymentsuite.stripe.view_template%"
-            - "%paymentsuite.stripe.scripts_template%"
+            - '@paymentsuite.bridge'
+            - '@form.factory'
+            - '%paymentsuite.stripe.public_key%'
+            - '%paymentsuite.stripe.view_template%'
+            - '%paymentsuite.stripe.scripts_template%'

--- a/src/PaymentSuite/StripeBundle/Resources/config/twig.yml
+++ b/src/PaymentSuite/StripeBundle/Resources/config/twig.yml
@@ -3,6 +3,6 @@ services:
     paymentsuite.stripe.twig_extension:
         class: PaymentSuite\StripeBundle\Twig\StripeExtension
         arguments:
-            - "@paymentsuite.stripe.template_render"
+            - '@paymentsuite.stripe.template_render'
         tags:
             - { name: twig.extension }

--- a/src/PaymentSuite/StripeBundle/StripeBundle.php
+++ b/src/PaymentSuite/StripeBundle/StripeBundle.php
@@ -44,7 +44,7 @@ class StripeBundle extends Bundle implements DependentBundleInterface
      *
      * @return array Bundle instances
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel): array
     {
         return [
             'PaymentSuite\PaymentCoreBundle\PaymentCoreBundle',

--- a/src/PaymentSuite/StripeBundle/composer.json
+++ b/src/PaymentSuite/StripeBundle/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.1",
 
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/form": "^2.7|^3.0",
-        "symfony/config": "^2.7|^3.0",
-        "symfony/http-kernel": "^2.7|^3.0",
-        "symfony/http-foundation": "^2.7|^3.0",
-        "symfony/dependency-injection": "^2.7|^3.0",
-        "mmoreram/symfony-bundle-dependencies": "^1.0",
+        "symfony/framework-bundle": "^3.4",
+        "symfony/form": "^3.4",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/http-foundation": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "mmoreram/symfony-bundle-dependencies": "^2.0",
 
         "twig/twig": "^1.23.1",
         "stripe/stripe-php": "3.4.0",
@@ -38,7 +38,7 @@
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -47,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }


### PR DESCRIPTION
We have done following:

- Drop support for symfony 2, php5 and phpunit 5
- Support symfony from 3.4.
- Support PHP from 7.1 and phpunit from 7
