### PR TITLE
add setting providers. Fix redsys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 composer.phar
 composer.lock
 phpunit.xml
+cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -12,6 +11,7 @@ matrix:
   fast_finish: true
 
 before_script:
+  - phpenv config-add travis.php.ini
   - composer update --no-interaction
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,11 @@
     ],
     "require": {
         "php": "^5.5|^7.0",
+        "ext-openssl": "*",
+        "ext-json": "*",
         "symfony/finder": "^2.8|^3.0",
         "symfony/config": "^2.8|^3.0",
+        "symfony/expression-language": "^2.8|^3.0",
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony/form": "^2.8|^3.0",
         "symfony/http-kernel": "^2.8|^3.0",
@@ -41,7 +44,9 @@
         "elcodi/fixtures-booster-bundle": "^2.0",
         "mmoreram/php-formatter": "1.1.0",
         "fabpot/php-cs-fixer": "1.11",
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "<6.0",
+        "symfony/twig-bundle": "^2.8|^3.0",
+        "symfony/templating": "^2.8|^3.0"
     },
     "replace": {
         "paymentsuite/bankwire-bundle": "self.version",

--- a/src/PaymentSuite/BankwireBundle/BankwireMethod.php
+++ b/src/PaymentSuite/BankwireBundle/BankwireMethod.php
@@ -23,12 +23,27 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 final class BankwireMethod implements PaymentMethodInterface
 {
     /**
+     * @var string
+     */
+    private $paymentName;
+
+    /**
+     * BankwireMethod constructor.
+     *
+     * @param string $paymentName
+     */
+    public function __construct($paymentName)
+    {
+        $this->paymentName = $paymentName;
+    }
+
+    /**
      * Get Bankwire method name.
      *
      * @return string Payment name
      */
     public function getPaymentName()
     {
-        return 'Bankwire';
+        return $this->paymentName;
     }
 }

--- a/src/PaymentSuite/BankwireBundle/DependencyInjection/BankwireExtension.php
+++ b/src/PaymentSuite/BankwireBundle/DependencyInjection/BankwireExtension.php
@@ -18,7 +18,6 @@ namespace PaymentSuite\BankwireBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
-
 use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteExtension;
 
 /**
@@ -42,8 +41,14 @@ class BankwireExtension extends AbstractPaymentSuiteExtension
             ]
         );
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('services.yml');
+
+        $this->addSettingsProvider(
+            $container,
+            'bankwire',
+            $config['settings_provider']
+        );
     }
 }

--- a/src/PaymentSuite/BankwireBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/BankwireBundle/DependencyInjection/Configuration.php
@@ -37,6 +37,8 @@ class Configuration extends AbstractPaymentSuiteConfiguration
                 ->append($this->addRouteConfiguration('payment_success'))
             ->end();
 
+        $this->addSettingsProviderConfiguration($rootNode);
+
         return $treeBuilder;
     }
 }

--- a/src/PaymentSuite/BankwireBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/BankwireBundle/Resources/config/controllers.yml
@@ -6,7 +6,7 @@ services:
     paymentsuite.bankwire.payment_controller:
         class: PaymentSuite\BankwireBundle\Controller\PaymentController
         arguments:
-            - "@paymentsuite.bankwire.manager"
-            - "@paymentsuite.bankwire.route_success"
-            - "@paymentsuite.bridge"
-            - "@router"
+            - '@paymentsuite.bankwire.manager'
+            - '@paymentsuite.bankwire.route_success'
+            - '@paymentsuite.bridge'
+            - '@router'

--- a/src/PaymentSuite/BankwireBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/BankwireBundle/Resources/config/services.yml
@@ -5,10 +5,15 @@ services:
     #
     paymentsuite.bankwire.method_factory:
         class: PaymentSuite\BankwireBundle\Services\BankwireMethodFactory
+        arguments:
+            - '@paymentsuite.bankwire.settings_provider'
 
     paymentsuite.bankwire.manager:
         class: PaymentSuite\BankwireBundle\Services\BankwireManager
         arguments:
-            - "@paymentsuite.bankwire.method_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.bankwire.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
+
+    paymentsuite.bankwire.settings_provider_default:
+        class: PaymentSuite\BankwireBundle\Services\BankwireSettingsProviderDefault

--- a/src/PaymentSuite/BankwireBundle/Services/BankwireMethodFactory.php
+++ b/src/PaymentSuite/BankwireBundle/Services/BankwireMethodFactory.php
@@ -16,6 +16,7 @@
 namespace PaymentSuite\BankwireBundle\Services;
 
 use PaymentSuite\BankwireBundle\BankwireMethod;
+use PaymentSuite\BankwireBundle\Services\Interfaces\BankwireSettingsProviderInterface;
 use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 
 /**
@@ -24,12 +25,27 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 class BankwireMethodFactory
 {
     /**
+     * @var BankwireSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
+     * BankwireMethodFactory constructor.
+     *
+     * @param BankwireSettingsProviderInterface $settingsProvider
+     */
+    public function __construct(BankwireSettingsProviderInterface $settingsProvider)
+    {
+        $this->settingsProvider = $settingsProvider;
+    }
+
+    /**
      * Create new PaymentMethodInterface instance.
      *
      * @return PaymentMethodInterface New instance
      */
     public function create()
     {
-        return new BankwireMethod();
+        return new BankwireMethod($this->settingsProvider->getPaymentName());
     }
 }

--- a/src/PaymentSuite/BankwireBundle/Services/BankwireSettingsProviderDefault.php
+++ b/src/PaymentSuite/BankwireBundle/Services/BankwireSettingsProviderDefault.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PaymentSuite\BankwireBundle\Services;
+
+use PaymentSuite\BankwireBundle\Services\Interfaces\BankwireSettingsProviderInterface;
+
+/**
+ * Class BankwireSettingsProviderDefault.
+ */
+class BankwireSettingsProviderDefault implements BankwireSettingsProviderInterface
+{
+    public function getPaymentName()
+    {
+        return 'Bankwire';
+    }
+}

--- a/src/PaymentSuite/BankwireBundle/Services/Interfaces/BankwireSettingsProviderInterface.php
+++ b/src/PaymentSuite/BankwireBundle/Services/Interfaces/BankwireSettingsProviderInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PaymentSuite\BankwireBundle\Services\Interfaces;
+
+use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
+
+interface BankwireSettingsProviderInterface extends PaymentMethodInterface
+{
+}

--- a/src/PaymentSuite/BankwireBundle/Tests/DependencyInjection/BankwireExtensionTest.php
+++ b/src/PaymentSuite/BankwireBundle/Tests/DependencyInjection/BankwireExtensionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace PaymentSuite\BankwireBundle\Tests\DependencyInjection;
+
+use PaymentSuite\BankwireBundle\Controller\PaymentController;
+use PaymentSuite\BankwireBundle\DependencyInjection\BankwireExtension;
+use PaymentSuite\BankwireBundle\Services\BankwireManager;
+use PaymentSuite\BankwireBundle\Services\BankwireMethodFactory;
+use PaymentSuite\BankwireBundle\Services\BankwireSettingsProviderDefault;
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRoute;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class BankwireExtensionTest extends TestCase
+{
+    public function testLoadDefaults()
+    {
+        $configs = [
+            'bankwire' => [
+                'settings_provider' => 'default',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new BankwireExtension();
+        $extension->load($configs, $container);
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.bankwire.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.bankwire.route_success')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.bankwire.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.bankwire.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.bankwire.manager'));
+        $this->assertSame(BankwireManager::class, $container->getDefinition('paymentsuite.bankwire.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.bankwire.method_factory'));
+        $this->assertSame(BankwireMethodFactory::class, $container->getDefinition('paymentsuite.bankwire.method_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.bankwire.settings_provider_default'));
+        $this->assertSame(BankwireSettingsProviderDefault::class, $container->getDefinition('paymentsuite.bankwire.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.bankwire.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.bankwire.settings_provider');
+        $this->assertSame('paymentsuite.bankwire.settings_provider_default', $settingsProvider->__toString());
+    }
+
+    public function testLoadCustomSettingsProvider()
+    {
+        $configs = [
+            'bankwire' => [
+                'settings_provider' => 'test.dummy_settings_provider',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new BankwireExtension();
+        $extension->load($configs, $container);
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.bankwire.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.bankwire.route_success')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.bankwire.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.bankwire.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.bankwire.manager'));
+        $this->assertSame(BankwireManager::class, $container->getDefinition('paymentsuite.bankwire.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.bankwire.method_factory'));
+        $this->assertSame(BankwireMethodFactory::class, $container->getDefinition('paymentsuite.bankwire.method_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.bankwire.settings_provider_default'));
+        $this->assertSame(BankwireSettingsProviderDefault::class, $container->getDefinition('paymentsuite.bankwire.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.bankwire.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.bankwire.settings_provider');
+        $this->assertSame('test.dummy_settings_provider', $settingsProvider->__toString());
+    }
+}

--- a/src/PaymentSuite/BankwireBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/BankwireBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PaymentSuite\BankwireBundle\Tests\DependencyInjection;
+
+use PaymentSuite\BankwireBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class ConfigurationTest extends TestCase
+{
+    public function testPaymentSuccessMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = [];
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('payment_success');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    public function testSettingProviderConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $settingsProvider = 'dummy.settings_provider.service';
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['settings_provider'] = $settingsProvider;
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+        $expectedConfig['settings_provider'] = $settingsProvider;
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    private function getRoutesConfiguration()
+    {
+        return [
+            'payment_success' => [
+                'route' => 'test-route-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+    }
+
+    private function getDefaultConfiguration()
+    {
+        $config = $this->getRoutesConfiguration();
+        $config['settings_provider'] = 'default';
+
+        return $config;
+    }
+}

--- a/src/PaymentSuite/BankwireBundle/Tests/Services/BankwireMethodFactoryTest.php
+++ b/src/PaymentSuite/BankwireBundle/Tests/Services/BankwireMethodFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PaymentSuite\BankwireBundle\Tests\Services;
+
+use PaymentSuite\BankwireBundle\BankwireMethod;
+use PaymentSuite\BankwireBundle\Services\BankwireMethodFactory;
+use PaymentSuite\BankwireBundle\Services\Interfaces\BankwireSettingsProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class BankwireMethodFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $paymentName = 'test_payment_name';
+
+        $settingsProvider = $this->prophesize(BankwireSettingsProviderInterface::class);
+        $settingsProvider
+            ->getPaymentName()
+            ->shouldBeCalled()
+            ->willReturn($paymentName);
+
+        $factory = new BankwireMethodFactory($settingsProvider->reveal());
+
+        $paymentMethod = $factory->create();
+
+        $this->assertInstanceOf(BankwireMethod::class, $paymentMethod);
+        $this->assertEquals($paymentName, $paymentMethod->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/BankwireBundle/Tests/Services/BankwireSettingsProviderDefaultTest.php
+++ b/src/PaymentSuite/BankwireBundle/Tests/Services/BankwireSettingsProviderDefaultTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PaymentSuite\BankwireBundle\Tests\Services;
+
+use PaymentSuite\BankwireBundle\BankwireBundle;
+use PaymentSuite\BankwireBundle\Services\BankwireSettingsProviderDefault;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutSettingsProviderDefault;
+use PHPUnit\Framework\TestCase;
+
+class BankwireSettingsProviderDefaultTest extends TestCase
+{
+    public function testCreateService()
+    {
+        $service = new BankwireSettingsProviderDefault();
+
+        $this->assertNotNull($service);
+        $this->assertEquals('Bankwire', $service->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/FreePaymentBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/FreePaymentBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,6 @@
 namespace PaymentSuite\FreePaymentBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-
 use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteConfiguration;
 
 /**
@@ -36,6 +35,8 @@ class Configuration extends AbstractPaymentSuiteConfiguration
             ->children()
                 ->append($this->addRouteConfiguration('payment_success'))
             ->end();
+
+        $this->addSettingsProviderConfiguration($rootNode);
 
         return $treeBuilder;
     }

--- a/src/PaymentSuite/FreePaymentBundle/DependencyInjection/FreePaymentExtension.php
+++ b/src/PaymentSuite/FreePaymentBundle/DependencyInjection/FreePaymentExtension.php
@@ -47,5 +47,11 @@ class FreePaymentExtension extends AbstractPaymentSuiteExtension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('services.yml');
+
+        $this->addSettingsProvider(
+            $container,
+            'freepayment',
+            $config['settings_provider']
+        );
     }
 }

--- a/src/PaymentSuite/FreePaymentBundle/FreePaymentMethod.php
+++ b/src/PaymentSuite/FreePaymentBundle/FreePaymentMethod.php
@@ -23,12 +23,27 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 final class FreePaymentMethod implements PaymentMethodInterface
 {
     /**
+     * @var string
+     */
+    private $paymentName;
+
+    /**
+     * FreePaymentMethod constructor.
+     *
+     * @param string $paymentName
+     */
+    public function __construct($paymentName)
+    {
+        $this->paymentName = $paymentName;
+    }
+
+    /**
      * Get Free payment method name.
      *
      * @return string Payment name
      */
     public function getPaymentName()
     {
-        return 'free_payment';
+        return $this->paymentName;
     }
 }

--- a/src/PaymentSuite/FreePaymentBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/FreePaymentBundle/Resources/config/services.yml
@@ -5,10 +5,15 @@ services:
     #
     paymentsuite.freepayment.method_factory:
         class: PaymentSuite\FreePaymentBundle\Services\FreePaymentMethodFactory
+        arguments:
+            - '@paymentsuite.freepayment.settings_provider'
 
     paymentsuite.freepayment.manager:
         class: PaymentSuite\FreePaymentBundle\Services\FreePaymentManager
         arguments:
-            - "@paymentsuite.freepayment.method_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.freepayment.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
+
+    paymentsuite.freepayment.settings_provider_default:
+        class: PaymentSuite\FreePaymentBundle\Services\FreePaymentSettingsProviderDefault

--- a/src/PaymentSuite/FreePaymentBundle/Services/FreePaymentMethodFactory.php
+++ b/src/PaymentSuite/FreePaymentBundle/Services/FreePaymentMethodFactory.php
@@ -16,6 +16,7 @@
 namespace PaymentSuite\FreePaymentBundle\Services;
 
 use PaymentSuite\FreePaymentBundle\FreePaymentMethod;
+use PaymentSuite\FreePaymentBundle\Services\Interfaces\FreePaymentSettingsProviderInterface;
 use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 
 /**
@@ -24,12 +25,27 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 class FreePaymentMethodFactory
 {
     /**
+     * @var FreePaymentSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
+     * FreePaymentMethodFactory constructor.
+     *
+     * @param FreePaymentSettingsProviderInterface $settingsProvider
+     */
+    public function __construct(FreePaymentSettingsProviderInterface $settingsProvider)
+    {
+        $this->settingsProvider = $settingsProvider;
+    }
+
+    /**
      * Create new PaymentMethodInterface instance.
      *
      * @return PaymentMethodInterface New instance
      */
     public function create()
     {
-        return new FreePaymentMethod();
+        return new FreePaymentMethod($this->settingsProvider->getPaymentName());
     }
 }

--- a/src/PaymentSuite/FreePaymentBundle/Services/FreePaymentSettingsProviderDefault.php
+++ b/src/PaymentSuite/FreePaymentBundle/Services/FreePaymentSettingsProviderDefault.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PaymentSuite\FreePaymentBundle\Services;
+
+use PaymentSuite\FreePaymentBundle\Services\Interfaces\FreePaymentSettingsProviderInterface;
+
+/**
+ * Class FreePaymentSettingsProviderDefault.
+ */
+class FreePaymentSettingsProviderDefault implements FreePaymentSettingsProviderInterface
+{
+    public function getPaymentName()
+    {
+        return 'free_payment';
+    }
+}

--- a/src/PaymentSuite/FreePaymentBundle/Services/Interfaces/FreePaymentSettingsProviderInterface.php
+++ b/src/PaymentSuite/FreePaymentBundle/Services/Interfaces/FreePaymentSettingsProviderInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PaymentSuite\FreePaymentBundle\Services\Interfaces;
+
+use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
+
+interface FreePaymentSettingsProviderInterface extends PaymentMethodInterface
+{
+}

--- a/src/PaymentSuite/FreePaymentBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/FreePaymentBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PaymentSuite\FreePaymentBundle\Tests\DependencyInjection;
+
+use PaymentSuite\FreePaymentBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class ConfigurationTest extends TestCase
+{
+    public function testPaymentSuccessMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = [];
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('payment_success');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    public function testSettingProviderConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $settingsProvider = 'dummy.settings_provider.service';
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['settings_provider'] = $settingsProvider;
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+        $expectedConfig['settings_provider'] = $settingsProvider;
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    private function getRoutesConfiguration()
+    {
+        return [
+            'payment_success' => [
+                'route' => 'test-route-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+    }
+
+    private function getDefaultConfiguration()
+    {
+        $config = $this->getRoutesConfiguration();
+        $config['settings_provider'] = 'default';
+
+        return $config;
+    }
+}

--- a/src/PaymentSuite/FreePaymentBundle/Tests/DependencyInjection/FreePaymentExtensionTest.php
+++ b/src/PaymentSuite/FreePaymentBundle/Tests/DependencyInjection/FreePaymentExtensionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace PaymentSuite\FreePaymentBundle\Tests\DependencyInjection;
+
+use PaymentSuite\FreePaymentBundle\Controller\PaymentController;
+use PaymentSuite\FreePaymentBundle\DependencyInjection\FreePaymentExtension;
+use PaymentSuite\FreePaymentBundle\Services\FreePaymentManager;
+use PaymentSuite\FreePaymentBundle\Services\FreePaymentMethodFactory;
+use PaymentSuite\FreePaymentBundle\Services\FreePaymentSettingsProviderDefault;
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRoute;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FreePaymentExtensionTest extends TestCase
+{
+    public function testLoadDefaults()
+    {
+        $configs = [
+            'freepayment' => [
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new FreePaymentExtension();
+        $extension->load($configs, $container);
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.freepayment.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.freepayment.route_success')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.freepayment.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.freepayment.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.freepayment.manager'));
+        $this->assertSame(FreePaymentManager::class, $container->getDefinition('paymentsuite.freepayment.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.freepayment.method_factory'));
+        $this->assertSame(FreePaymentMethodFactory::class, $container->getDefinition('paymentsuite.freepayment.method_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.freepayment.settings_provider_default'));
+        $this->assertSame(FreePaymentSettingsProviderDefault::class, $container->getDefinition('paymentsuite.freepayment.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.freepayment.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.freepayment.settings_provider');
+        $this->assertSame('paymentsuite.freepayment.settings_provider_default', $settingsProvider->__toString());
+    }
+
+    public function testLoadCustomSettingsProvider()
+    {
+        $configs = [
+            'freepayment' => [
+                'settings_provider' => 'test.dummy_settings_provider',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new FreePaymentExtension();
+        $extension->load($configs, $container);
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.freepayment.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.freepayment.route_success')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.freepayment.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.freepayment.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.freepayment.manager'));
+        $this->assertSame(FreePaymentManager::class, $container->getDefinition('paymentsuite.freepayment.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.freepayment.method_factory'));
+        $this->assertSame(FreePaymentMethodFactory::class, $container->getDefinition('paymentsuite.freepayment.method_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.freepayment.settings_provider_default'));
+        $this->assertSame(FreePaymentSettingsProviderDefault::class, $container->getDefinition('paymentsuite.freepayment.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.freepayment.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.freepayment.settings_provider');
+        $this->assertSame('test.dummy_settings_provider', $settingsProvider->__toString());
+    }
+}

--- a/src/PaymentSuite/FreePaymentBundle/Tests/Services/FreePaymentMethodFactoryTest.php
+++ b/src/PaymentSuite/FreePaymentBundle/Tests/Services/FreePaymentMethodFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PaymentSuite\FreePaymentBundle\Tests\Services;
+
+use PaymentSuite\FreePaymentBundle\FreePaymentMethod;
+use PaymentSuite\FreePaymentBundle\Services\FreePaymentMethodFactory;
+use PaymentSuite\FreePaymentBundle\Services\Interfaces\FreePaymentSettingsProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class FreePaymentMethodFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $paymentName = 'test_payment_name';
+
+        $settingsProvider = $this->prophesize(FreePaymentSettingsProviderInterface::class);
+        $settingsProvider
+            ->getPaymentName()
+            ->shouldBeCalled()
+            ->willReturn($paymentName);
+
+        $factory = new FreePaymentMethodFactory($settingsProvider->reveal());
+
+        $paymentMethod = $factory->create();
+
+        $this->assertInstanceOf(FreePaymentMethod::class, $paymentMethod);
+        $this->assertEquals($paymentName, $paymentMethod->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/FreePaymentBundle/Tests/Services/FreePaymentSettingsProviderDefaultTest.php
+++ b/src/PaymentSuite/FreePaymentBundle/Tests/Services/FreePaymentSettingsProviderDefaultTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PaymentSuite\FreePaymentBundle\Tests\Services;
+
+use PaymentSuite\FreePaymentBundle\Services\FreePaymentSettingsProviderDefault;
+use PHPUnit\Framework\TestCase;
+
+class FreePaymentSettingsProviderDefaultTest extends TestCase
+{
+    public function testCreateService()
+    {
+        $service = new FreePaymentSettingsProviderDefault();
+
+        $this->assertEquals('free_payment', $service->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Controller/PaymentController.php
+++ b/src/PaymentSuite/PaylandsBundle/Controller/PaymentController.php
@@ -16,6 +16,8 @@
 namespace PaymentSuite\PaylandsBundle\Controller;
 
 use PaymentSuite\PaylandsBundle\Exception\CardInvalidException;
+use PaymentSuite\PaylandsBundle\PaylandsMethod;
+use PaymentSuite\PaylandsBundle\Services\Interfaces\PaylandsSettingsProviderInterface;
 use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
 use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
 use PaymentSuite\PaylandsBundle\Services\PaylandsManager;
@@ -70,26 +72,34 @@ class PaymentController extends Controller
     private $urlGenerator;
 
     /**
+     * @var PaylandsSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
      * PaymentController constructor.
      *
-     * @param PaylandsManager                     $paymentManager
-     * @param PaylandsFormFactory                 $paymentFormFactory
+     * @param PaylandsManager $paymentManager
+     * @param PaylandsFormFactory $paymentFormFactory
      * @param RedirectionRouteCollection $redirectionRoutes
-     * @param PaymentBridgeInterface              $paymentBridge
-     * @param UrlGeneratorInterface               $urlGenerator
+     * @param PaymentBridgeInterface $paymentBridge
+     * @param UrlGeneratorInterface $urlGenerator
+     * @param PaylandsSettingsProviderInterface $settingsProvider
      */
     public function __construct(
         PaylandsManager $paymentManager,
         PaylandsFormFactory $paymentFormFactory,
         RedirectionRouteCollection $redirectionRoutes,
         PaymentBridgeInterface $paymentBridge,
-        UrlGeneratorInterface $urlGenerator
+        UrlGeneratorInterface $urlGenerator,
+        PaylandsSettingsProviderInterface $settingsProvider
     ) {
         $this->paymentManager = $paymentManager;
         $this->paymentFormFactory = $paymentFormFactory;
         $this->redirectionRoutes = $redirectionRoutes;
         $this->paymentBridge = $paymentBridge;
         $this->urlGenerator = $urlGenerator;
+        $this->settingsProvider = $settingsProvider;
     }
 
     public function executeAction(Request $request)
@@ -99,7 +109,7 @@ class PaymentController extends Controller
          */
         $form = $this
             ->paymentFormFactory
-            ->create();
+            ->createEmpty();
 
         $form->handleRequest($request);
 
@@ -112,6 +122,7 @@ class PaymentController extends Controller
                 throw new PaymentException();
             }
 
+            /** @var PaylandsMethod $paymentMethod */
             $paymentMethod = $form->getData();
 
             $this

--- a/src/PaymentSuite/PaylandsBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/PaylandsBundle/DependencyInjection/Configuration.php
@@ -115,6 +115,22 @@ class Configuration extends AbstractPaymentSuiteConfiguration
                 ->append($this->addRouteConfiguration('payment_card_invalid'))
             ->end();
 
+        $this->addSettingsProviderConfiguration($rootNode);
+
         return $treeBuilder;
+    }
+
+    protected function setDefaultSettings($config)
+    {
+        $config['api_key'] = 'dummy_api_key';
+        $config['signature'] = 'dummy_signature';
+        $config['services'] = [
+            [
+                'currency' => 'EUR',
+                'service' => 'dummy_service',
+            ]
+        ];
+
+        return $config;
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/DependencyInjection/PaylandsExtension.php
+++ b/src/PaymentSuite/PaylandsBundle/DependencyInjection/PaylandsExtension.php
@@ -45,6 +45,7 @@ class PaylandsExtension extends AbstractPaymentSuiteExtension
                 'view_template' => $config['templates']['view'],
                 'scripts_template' => $config['templates']['scripts'],
                 'validation_service' => $config['validation_service'],
+                'payment_services' => $this->marshalPaymentServices($config['services']),
             ]
         );
 
@@ -59,24 +60,23 @@ class PaylandsExtension extends AbstractPaymentSuiteExtension
         $loader->load('services.yml');
 
         $this->registerApiClient($container, $config);
+
+        $this->addSettingsProvider($container, 'paylands', $config['settings_provider']);
     }
 
     /**
-     * Registers the list of available currency dependant Paylands' services to use.
+     * @param array $services
      *
-     * @param ContainerBuilder $containerBuilder
-     * @param array            $config
+     * @return array
      */
-    protected function registerEndpointServices(ContainerBuilder $containerBuilder, array $config)
+    protected function marshalPaymentServices($services)
     {
-        $resolverDefinition = $containerBuilder->getDefinition('paymentsuite.paylands.currency_service_resolver');
-
-        foreach ($config as $option) {
-            $resolverDefinition->addMethodCall('addService', [
-                $option['currency'],
-                $option['service'],
-            ]);
+        $result = [];
+        foreach ($services as $option) {
+            $result[$option['currency']] = $option['service'];
         }
+
+        return $result;
     }
 
     /**
@@ -117,8 +117,6 @@ class PaylandsExtension extends AbstractPaymentSuiteExtension
 
         if (Configuration::API_CLIENT_DEFAULT == $config['api_client']) {
             $this->resolveApiClientInterfaces($containerBuilder, $config['interfaces']);
-
-            $this->registerEndpointServices($containerBuilder, $config['services']);
         }
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/PaylandsMethod.php
+++ b/src/PaymentSuite/PaylandsBundle/PaylandsMethod.php
@@ -99,6 +99,21 @@ final class PaylandsMethod implements PaymentMethodInterface
     private $paymentStatus;
 
     /**
+     * @var string
+     */
+    private $paymentName;
+
+    /**
+     * PaylandsMethod constructor.
+     *
+     * @param string $paymentName
+     */
+    public function __construct($paymentName)
+    {
+        $this->paymentName = $paymentName;
+    }
+
+    /**
      * @return string
      */
     public function getCustomerExternalId()
@@ -323,7 +338,7 @@ final class PaylandsMethod implements PaymentMethodInterface
      */
     public function isOnlyTokenizeCard()
     {
-        return $this->onlyTokenizeCard;
+        return (bool) $this->onlyTokenizeCard;
     }
 
     /**
@@ -385,6 +400,6 @@ final class PaylandsMethod implements PaymentMethodInterface
      */
     public function getPaymentName()
     {
-        return 'Paylands';
+        return $this->paymentName;
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/api.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/api.yml
@@ -8,7 +8,7 @@ services:
         public: false
         arguments:
             - '@paymentsuite.paylands.api.discovery_proxy'
-            - '%paymentsuite.paylands.signature%'
+            - "@=service('paymentsuite.paylands.settings_provider').getApiSignature()"
 
     paymentsuite.paylands.api.client_factory:
         class: WAM\Paylands\ClientFactory
@@ -16,7 +16,7 @@ services:
         arguments:
             - '@paymentsuite.paylands.api.request_factory'
             - '@paymentsuite.paylands.api.discovery_proxy'
-            - '%paymentsuite.paylands.api_key%'
+            - "@=service('paymentsuite.paylands.settings_provider').getApiKey()"
             - '%paymentsuite.paylands.api_url%'
 
     paymentsuite.paylands.api.client_default:
@@ -25,7 +25,7 @@ services:
         public: false
         calls:
             - [setOperative, ['%paymentsuite.paylands.operative%']]
-            - [setTemplates, ['%paymentsuite.paylands.fallback_template_uuid%', '%paymentsuite.paylands.i18n_template_uuids%']]
+            - [setTemplates, ['%paymentsuite.paylands.fallback_template_uuid%', "@=service('paymentsuite.paylands.settings_provider').getI18nCardTemplates()"]]
 
     paymentsuite.paylands.api.adapter:
         class: PaymentSuite\PaylandsBundle\Services\PaylandsApiAdapter

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/controllers.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/controllers.yml
@@ -8,3 +8,4 @@ services:
             - '@paymentsuite.paylands.routes'
             - '@paymentsuite.bridge'
             - '@router'
+            - '@paymentsuite.paylands.settings_provider'

--- a/src/PaymentSuite/PaylandsBundle/Resources/config/services/payment.yml
+++ b/src/PaymentSuite/PaylandsBundle/Resources/config/services/payment.yml
@@ -5,8 +5,7 @@ services:
         arguments:
             - '@form.factory'
             - '@router'
-
-
+            - '@paymentsuite.paylands.settings_provider'
 
     paymentsuite.paylands.manager:
         class: PaymentSuite\PaylandsBundle\Services\PaylandsManager
@@ -31,5 +30,13 @@ services:
         public: false
         arguments:
             - '@paymentsuite.bridge'
-        calls:
-            - ['setValidationService', ['%paymentsuite.paylands.validation_service%']]
+            - '@paymentsuite.paylands.settings_provider'
+
+    paymentsuite.paylands.settings_provider_default:
+        class: PaymentSuite\PaylandsBundle\Services\PaylandsSettingsProviderDefault
+        arguments:
+            - '%paymentsuite.paylands.api_key%'
+            - '%paymentsuite.paylands.signature%'
+            - '%paymentsuite.paylands.payment_services%'
+            - '%paymentsuite.paylands.i18n_template_uuids%'
+            - '%paymentsuite.paylands.validation_service%'

--- a/src/PaymentSuite/PaylandsBundle/Services/Interfaces/PaylandsSettingsProviderInterface.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/Interfaces/PaylandsSettingsProviderInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PaymentSuite\PaylandsBundle\Services\Interfaces;
+
+use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
+
+interface PaylandsSettingsProviderInterface extends PaymentMethodInterface
+{
+    /**
+     * Gets paylands API key.
+     *
+     * @return string
+     */
+    public function getApiKey();
+
+    /**
+     * Gets paylands API signature.
+     *
+     * @return string
+     */
+    public function getApiSignature();
+
+    /**
+     * Gets paylands validation service id.
+     *
+     * @return string|null
+     */
+    public function getValidationService();
+
+    /**
+     * Gets paylands payment services' id by currency.
+     *
+     * Example:
+     * [
+     *     'currency' => 'EUR',
+     *     'service' => '...uuid...',
+     * ]
+     *
+     * @return array
+     */
+    public function getPaymentServices();
+
+    /**
+     * Gets paylands i18n card templates to be shown when capturing card number.
+     *
+     * Example:
+     * [
+     *     'en' => '...uuid...',
+     *     'es' => '...uuid...',
+     * ]
+     *
+     * @return array
+     */
+    public function getI18nCardTemplates();
+}

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsCurrencyServiceResolver.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsCurrencyServiceResolver.php
@@ -15,6 +15,7 @@
 
 namespace PaymentSuite\PaylandsBundle\Services;
 
+use PaymentSuite\PaylandsBundle\Services\Interfaces\PaylandsSettingsProviderInterface;
 use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
 
 /**
@@ -25,49 +26,27 @@ use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
 class PaylandsCurrencyServiceResolver
 {
     /**
-     * UUIDs of the services to pay through by currency.
-     *
-     * @var array
-     */
-    protected $services;
-
-    /**
-     * UUID of the service to validate card against.
-     *
-     * @var string
-     */
-    protected $validationService;
-
-    /**
      * @var PaymentBridgeInterface
      */
     protected $paymentBridge;
 
     /**
-     * PaylandsCurrencyServiceResolver constructor.
-     *
-     * @param PaymentBridgeInterface $paymentBridge
+     * @var PaylandsSettingsProviderInterface
      */
-    public function __construct(PaymentBridgeInterface $paymentBridge)
-    {
-        $this->paymentBridge = $paymentBridge;
-
-        $this->services = [];
-    }
+    private $settingsProvider;
 
     /**
-     * Adds a new service ID for a given currency ISO code.
+     * PaylandsCurrencyServiceResolver constructor.
      *
-     * @param $currency
-     * @param $service
-     *
-     * @return $this Self instance
+     * @param PaymentBridgeInterface            $paymentBridge
+     * @param PaylandsSettingsProviderInterface $settingsProvider
      */
-    public function addService($currency, $service)
-    {
-        $this->services[$currency] = $service;
-
-        return $this;
+    public function __construct(
+        PaymentBridgeInterface $paymentBridge,
+        PaylandsSettingsProviderInterface $settingsProvider
+    ) {
+        $this->paymentBridge = $paymentBridge;
+        $this->settingsProvider = $settingsProvider;
     }
 
     /**
@@ -79,8 +58,9 @@ class PaylandsCurrencyServiceResolver
     {
         $currency = $this->paymentBridge->getCurrency();
 
-        if (key_exists($currency, $this->services)) {
-            return $this->services[$currency];
+        $paymentServices = $this->settingsProvider->getPaymentServices();
+        if (key_exists($currency, $paymentServices)) {
+            return $paymentServices[$currency];
         }
 
         return '';
@@ -91,22 +71,10 @@ class PaylandsCurrencyServiceResolver
      */
     public function getValidationService()
     {
-        if (!is_null($this->validationService)) {
-            return $this->validationService;
+        if (!is_null($this->settingsProvider->getValidationService())) {
+            return $this->settingsProvider->getValidationService();
         }
 
         return $this->getService();
-    }
-
-    /**
-     * @param string $validationService
-     *
-     * @return PaylandsCurrencyServiceResolver $this
-     */
-    public function setValidationService($validationService = null)
-    {
-        $this->validationService = $validationService;
-
-        return $this;
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsFormFactory.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsFormFactory.php
@@ -15,9 +15,9 @@
 
 namespace PaymentSuite\PaylandsBundle\Services;
 
-use PaymentSuite\PaylandsBundle\Exception\CreateFormException;
 use PaymentSuite\PaylandsBundle\Form\Type\PaylandsType;
 use PaymentSuite\PaylandsBundle\PaylandsMethod;
+use PaymentSuite\PaylandsBundle\Services\Interfaces\PaylandsSettingsProviderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -40,46 +40,70 @@ class PaylandsFormFactory
     private $urlGenerator;
 
     /**
+     * @var PaylandsSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
      * PaylandsFormFactory constructor.
      *
-     * @param FormFactoryInterface  $formFactory
-     * @param UrlGeneratorInterface $urlGenerator
+     * @param FormFactoryInterface              $formFactory
+     * @param UrlGeneratorInterface             $urlGenerator
+     * @param PaylandsSettingsProviderInterface $settingsProvider
      */
-    public function __construct(FormFactoryInterface $formFactory, UrlGeneratorInterface $urlGenerator)
-    {
+    public function __construct(
+        FormFactoryInterface $formFactory,
+        UrlGeneratorInterface $urlGenerator,
+        PaylandsSettingsProviderInterface $settingsProvider
+    ) {
         $this->formFactory = $formFactory;
         $this->urlGenerator = $urlGenerator;
+        $this->settingsProvider = $settingsProvider;
     }
 
     /**
      * Creates the payment form.
      *
-     * @param mixed $data
-     * @param array $options
+     * @param PaylandsMethod $data
      *
      * @return FormInterface
-     *
-     * @throws CreateFormException
      */
-    public function create($data = null, array $options = [])
+    private function create(PaylandsMethod $data)
     {
-        $options = array_merge($options, [
+        $options = [
             'action' => $this->urlGenerator->generate('paymentsuite_paylands_execute'),
             'method' => 'POST',
-        ]);
+        ];
 
-        if (is_array($data)) {
-            $data = $this
-                ->formFactory
-                ->create(PaylandsType::class)
-                ->submit($data, true)
-                ->getData();
-        }
+        return $this->formFactory->create(PaylandsType::class, $data, $options);
+    }
 
-        if (is_null($data) || $data instanceof PaylandsMethod) {
-            return $this->formFactory->create(PaylandsType::class, $data, $options);
-        }
+    /**
+     * @return FormInterface
+     */
+    public function createEmpty()
+    {
+        $paymentMethod = new PaylandsMethod($this->settingsProvider->getPaymentName());
 
-        throw new CreateFormException();
+        return $this->create($paymentMethod);
+    }
+
+    /**
+     * @param string $customerExternalId
+     * @param string $customerToken
+     * @param bool   $onlyTokenizeCard
+     *
+     * @return FormInterface
+     */
+    public function createForTransaction($customerExternalId, $customerToken, $onlyTokenizeCard)
+    {
+        $paymentMethod = new PaylandsMethod($this->settingsProvider->getPaymentName());
+
+        $paymentMethod
+            ->setCustomerExternalId($customerExternalId)
+            ->setCustomerToken($customerToken)
+            ->setOnlyTokenizeCard($onlyTokenizeCard);
+
+        return $this->create($paymentMethod);
     }
 }

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsSettingsProviderDefault.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsSettingsProviderDefault.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace PaymentSuite\PaylandsBundle\Services;
+
+use PaymentSuite\PaylandsBundle\Services\Interfaces\PaylandsSettingsProviderInterface;
+
+class PaylandsSettingsProviderDefault implements PaylandsSettingsProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @var string
+     */
+    private $apiSignature;
+
+    /**
+     * @var array
+     */
+    private $paymentServices;
+
+    /**
+     * @var string|null
+     */
+    private $validationService;
+
+    /**
+     * @var array|null
+     */
+    private $i18nCardTemplates;
+
+    /**
+     * PaylandsSettingsProviderDefault constructor.
+     *
+     * @param string      $apiKey
+     * @param string      $apiSignature
+     * @param array       $paymentServices
+     * @param array  $i18nCardTemplates
+     * @param string|null $validationService
+     */
+    public function __construct(
+        $apiKey,
+        $apiSignature,
+        $paymentServices,
+        $i18nCardTemplates,
+        $validationService
+    ) {
+        $this->apiKey = $apiKey;
+        $this->apiSignature = $apiSignature;
+        $this->paymentServices = $paymentServices;
+        $this->validationService = $validationService;
+        $this->i18nCardTemplates = $i18nCardTemplates;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiSignature()
+    {
+        return $this->apiSignature;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValidationService()
+    {
+        return $this->validationService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaymentServices()
+    {
+        return $this->paymentServices;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getI18nCardTemplates()
+    {
+        return  $this->i18nCardTemplates;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaymentName()
+    {
+        return 'Paylands';
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Services/PaylandsViewRenderer.php
+++ b/src/PaymentSuite/PaylandsBundle/Services/PaylandsViewRenderer.php
@@ -83,9 +83,12 @@ class PaylandsViewRenderer
 
     /**
      * @param \Twig_Environment $environment
-     * @param array             $options
+     * @param array $options
      *
      * @return string
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
      */
     public function renderView(\Twig_Environment $environment, array $options = array())
     {
@@ -96,11 +99,9 @@ class PaylandsViewRenderer
 
         $response = $this->apiClient->createCustomer($options['customer_ext_id']);
 
-        $form = $this->paymentFormFactory->create([
-            'customerExternalId' => $options['customer_ext_id'],
-            'customerToken' => $response['Customer']['token'],
-            'onlyTokenizeCard' => (int) $options['only_tokenize_card'],
-        ]);
+        $form = $this
+            ->paymentFormFactory
+            ->createForTransaction($options['customer_ext_id'], $response['Customer']['token'], (bool) $options['only_tokenize_card']);
 
         $renderedView = $environment->render($options['template'] ?: $this->viewTemplate, [
             'paylands_form' => $form->createView(),

--- a/src/PaymentSuite/PaylandsBundle/Tests/Controller/PaymentControllerTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Controller/PaymentControllerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace PaymentSuite\PaylandsBundle\Tests\Controller;
+
+use PaymentSuite\PaylandsBundle\Controller\PaymentController;
+use PaymentSuite\PaylandsBundle\Exception\CardInvalidException;
+use PaymentSuite\PaylandsBundle\Form\Type\PaylandsType;
+use PaymentSuite\PaylandsBundle\PaylandsMethod;
+use PaymentSuite\PaylandsBundle\Services\Interfaces\PaylandsSettingsProviderInterface;
+use PaymentSuite\PaylandsBundle\Services\PaylandsFormFactory;
+use PaymentSuite\PaylandsBundle\Services\PaylandsManager;
+use PaymentSuite\PaylandsBundle\Services\PaylandsSettingsProviderDefault;
+use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRoute;
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRouteCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class PaymentControllerTest extends TestCase
+{
+    /**
+     * @var RedirectionRouteCollection
+     */
+    private $redirectionRoutes;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var PaymentBridgeInterface
+     */
+    private $paymentBridge;
+
+    /**
+     * @var PaylandsFormFactory
+     */
+    private $paymentFormFactory;
+    /**
+     * @var PaylandsSettingsProviderDefault
+     */
+    private $settingsProvider;
+
+    protected function setUp()
+    {
+        $this->redirectionRoutes = $this->getRedirectionRoutesCollection();
+        $this->urlGenerator = $this->getUrlGeneratorMock();
+        $this->paymentBridge = $this->getPaymentBridgeMock();
+        $this->paymentFormFactory = new PaylandsFormFactory(
+            $this->getFormFactory(),
+            $this->urlGenerator,
+            $this->getSettingsProviderMock()
+        );
+        $this->settingsProvider = new PaylandsSettingsProviderDefault('api_key', 'api_signature', [], [], 'validation_service');
+    }
+
+    public function testExecuteAction()
+    {
+        $isValidPaymentMethod = function (PaylandsMethod $method) {
+            $this->assertEquals('test-name', $method->getPaymentName());
+            $this->assertEquals('123', $method->getCustomerExternalId());
+            $this->assertEquals('cust-token', $method->getCustomerToken());
+            $this->assertEquals('card-uuid', $method->getCardUuid());
+            $this->assertTrue($method->isOnlyTokenizeCard());
+
+            return true;
+        };
+
+        $paymentManager = $this->prophesize(PaylandsManager::class);
+        $paymentManager
+            ->processPayment(Argument::that($isValidPaymentMethod))
+            ->shouldBeCalled();
+
+        $controller = new PaymentController(
+            $paymentManager->reveal(),
+            $this->paymentFormFactory,
+            $this->redirectionRoutes,
+            $this->paymentBridge,
+            $this->urlGenerator,
+            $this->settingsProvider
+        );
+
+        $request = Request::create('/', 'POST', [
+            'paylands' => [
+                'customerExternalId' => '123',
+                'customerToken' => 'cust-token',
+                'cardUuid' => 'card-uuid',
+                'onlyTokenizeCard' => true,
+            ],
+        ]);
+
+        $response = $controller->executeAction($request);
+
+        $this->assertEquals('/pyalands/success', $response->getTargetUrl());
+    }
+
+    public function testExecuteActionIfInvalidForm()
+    {
+        $paymentManager = $this->prophesize(PaylandsManager::class);
+        $paymentManager
+            ->processPayment(Argument::any())
+            ->shouldNotBeCalled();
+
+        $controller = new PaymentController(
+            $paymentManager->reveal(),
+            $this->paymentFormFactory,
+            $this->redirectionRoutes,
+            $this->paymentBridge,
+            $this->urlGenerator,
+            $this->settingsProvider
+        );
+
+        $request = Request::create('/', 'POST', []);
+
+        $response = $controller->executeAction($request);
+
+        $this->assertEquals('/pyalands/failure', $response->getTargetUrl());
+    }
+
+    public function testExecuteActionIfCardInvalid()
+    {
+        $isValidPaymentMethod = function (PaylandsMethod $method) {
+            $this->assertEquals('test-name', $method->getPaymentName());
+            $this->assertEquals('123', $method->getCustomerExternalId());
+            $this->assertEquals('cust-token', $method->getCustomerToken());
+            $this->assertEquals('card-uuid', $method->getCardUuid());
+            $this->assertTrue($method->isOnlyTokenizeCard());
+
+            return true;
+        };
+
+        $paymentManager = $this->prophesize(PaylandsManager::class);
+        $paymentManager
+            ->processPayment(Argument::that($isValidPaymentMethod))
+            ->shouldBeCalled()
+            ->willThrow(new CardInvalidException());
+
+        $controller = new PaymentController(
+            $paymentManager->reveal(),
+            $this->paymentFormFactory,
+            $this->redirectionRoutes,
+            $this->paymentBridge,
+            $this->urlGenerator,
+            $this->settingsProvider
+        );
+
+        $request = Request::create('/', 'POST', [
+            'paylands' => [
+                'customerExternalId' => '123',
+                'customerToken' => 'cust-token',
+                'cardUuid' => 'card-uuid',
+                'onlyTokenizeCard' => true,
+            ],
+        ]);
+
+        $response = $controller->executeAction($request);
+
+        $this->assertEquals('/pyalands/card_invalid', $response->getTargetUrl());
+    }
+
+    public function testExecuteActionIfProcessPaymentError()
+    {
+        $isValidPaymentMethod = function (PaylandsMethod $method) {
+            $this->assertEquals('test-name', $method->getPaymentName());
+            $this->assertEquals('123', $method->getCustomerExternalId());
+            $this->assertEquals('cust-token', $method->getCustomerToken());
+            $this->assertEquals('card-uuid', $method->getCardUuid());
+            $this->assertTrue($method->isOnlyTokenizeCard());
+
+            return true;
+        };
+
+        $paymentManager = $this->prophesize(PaylandsManager::class);
+        $paymentManager
+            ->processPayment(Argument::that($isValidPaymentMethod))
+            ->shouldBeCalled()
+            ->willThrow(new \Exception());
+
+        $controller = new PaymentController(
+            $paymentManager->reveal(),
+            $this->paymentFormFactory,
+            $this->redirectionRoutes,
+            $this->paymentBridge,
+            $this->urlGenerator,
+            $this->settingsProvider
+        );
+
+        $request = Request::create('/', 'POST', [
+            'paylands' => [
+                'customerExternalId' => '123',
+                'customerToken' => 'cust-token',
+                'cardUuid' => 'card-uuid',
+                'onlyTokenizeCard' => true,
+            ],
+        ]);
+
+        $response = $controller->executeAction($request);
+
+        $this->assertEquals('/pyalands/failure', $response->getTargetUrl());
+    }
+
+    /**
+     * @return UrlGeneratorInterface
+     */
+    private function getUrlGeneratorMock()
+    {
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->generate('paymentsuite_paylands_execute')
+            ->willReturn('/paylands/execute');
+        $urlGenerator
+            ->generate('success', Argument::cetera())
+            ->willReturn('/pyalands/success');
+        $urlGenerator
+            ->generate('failure', Argument::cetera())
+            ->willReturn('/pyalands/failure');
+        $urlGenerator
+            ->generate('card_invalid', Argument::cetera())
+            ->willReturn('/pyalands/card_invalid');
+
+        return $urlGenerator->reveal();
+    }
+
+    /**
+     * @return RedirectionRouteCollection
+     */
+    private function getRedirectionRoutesCollection()
+    {
+        $redirectionRoutes = new RedirectionRouteCollection();
+        $redirectionRoutes->addRedirectionRoute(new RedirectionRoute('success', false, ''), 'success');
+        $redirectionRoutes->addRedirectionRoute(new RedirectionRoute('failure', false, ''), 'failure');
+        $redirectionRoutes->addRedirectionRoute(new RedirectionRoute('card_invalid', false, ''), 'card_invalid');
+
+        return $redirectionRoutes;
+    }
+
+    /**
+     * @return PaylandsSettingsProviderInterface
+     */
+    private function getSettingsProviderMock()
+    {
+        $settingsProvider = $this->prophesize(PaylandsSettingsProviderInterface::class);
+        $settingsProvider
+            ->getPaymentName()
+            ->willReturn('test-name');
+
+        return $settingsProvider->reveal();
+    }
+
+    /**
+     * @return FormFactoryInterface
+     */
+    private function getFormFactory()
+    {
+        $formFactory = Forms::createFormFactoryBuilder()
+            ->addType(new PaylandsType())
+            ->addExtension(new HttpFoundationExtension())
+            ->getFormFactory();
+
+        return $formFactory;
+    }
+
+    /**
+     * @return PaymentBridgeInterface
+     */
+    private function getPaymentBridgeMock()
+    {
+        $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
+
+        return $paymentBridge->reveal();
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -70,12 +70,25 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $input2 = array_merge($input1, $i18nTemplates);
         $expectations2 = array_merge($expectations1, $i18nTemplates);
 
+        $settingsProvider = [
+            'settings_provider' => 'test.settings_provider.service_id',
+            'api_key' => null,
+            'signature' => null,
+            'services' => null,
+        ];
+
+        $input3 = array_merge($input1, $settingsProvider);
+        $expectations3 = array_merge($expectations1, $this->getSettingsProviderConfiguration());
+
         return [
             'test default configuration' => [
                 $input1, $expectations1,
             ],
             'test i18n templates configuration' => [
                 $input2, $expectations2,
+            ],
+            'test settings provider configuration' => [
+                $input3, $expectations3,
             ],
         ];
     }
@@ -100,6 +113,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             ],
             'api_client' => Configuration::API_CLIENT_DEFAULT,
             'validation_service' => null,
+            'settings_provider' => 'default',
         ];
     }
 
@@ -125,6 +139,18 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'route' => 'test-route-card-invalid',
                 'order_append' => true,
                 'order_append_field' => 'id',
+            ],
+        ];
+    }
+
+    protected function getSettingsProviderConfiguration()
+    {
+        return [
+            'settings_provider' => 'test.settings_provider.service_id',
+            'api_key' => 'dummy_api_key',
+            'signature' => 'dummy_signature',
+            'services' => [
+                ['currency' => 'EUR', 'service' => 'dummy_service'],
             ],
         ];
     }

--- a/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/PaylandsExtensionTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/DependencyInjection/PaylandsExtensionTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace PaymentSuite\PaylandsBundle\Tests\DependencyInjection;
+
+use PaymentSuite\PaylandsBundle\Controller\PaymentController;
+use PaymentSuite\PaylandsBundle\DependencyInjection\PaylandsExtension;
+use PaymentSuite\PaylandsBundle\Services\PaylandsApiAdapter;
+use PaymentSuite\PaylandsBundle\Services\PaylandsCurrencyServiceResolver;
+use PaymentSuite\PaylandsBundle\Services\PaylandsFormFactory;
+use PaymentSuite\PaylandsBundle\Services\PaylandsManager;
+use PaymentSuite\PaylandsBundle\Services\PaylandsSettingsProviderDefault;
+use PaymentSuite\PaylandsBundle\Services\PaylandsViewRenderer;
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRoute;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use WAM\Paylands\Client;
+use WAM\Paylands\ClientFactory;
+use WAM\Paylands\DiscoveryProxy;
+use WAM\Paylands\RequestFactory;
+
+class PaylandsExtensionTest extends TestCase
+{
+    public function testLoadDefaults()
+    {
+        $configs = [
+            'paylands' => [
+                'api_key' => 'test-key',
+                'signature' => 'test-signature',
+                'services' => [
+                    ['currency' => 'EUR', 'service' => 'eur-service'],
+                    ['currency' => 'USD', 'service' => 'usd-service'],
+                ],
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_failure' => [
+                    'route' => 'test-route-failure',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_card_invalid' => [
+                    'route' => 'test-route-card-invalid',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new PaylandsExtension();
+        $extension->load($configs, $container);
+
+        //Parameters
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.api_key'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.signature'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.operative'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.sandbox'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.fallback_template_uuid'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.i18n_template_uuids'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.api_url'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.view_template'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.scripts_template'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.validation_service'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.payment_services'));
+
+        $this->assertSame('test-key', $container->getParameter('paymentsuite.paylands.api_key'));
+        $this->assertSame('test-signature', $container->getParameter('paymentsuite.paylands.signature'));
+        $this->assertSame('AUTHORIZATION', $container->getParameter('paymentsuite.paylands.operative'));
+        $this->assertFalse($container->getParameter('paymentsuite.paylands.sandbox'));
+        $this->assertSame('default', $container->getParameter('paymentsuite.paylands.fallback_template_uuid'));
+        $this->assertSame([], $container->getParameter('paymentsuite.paylands.i18n_template_uuids'));
+        $this->assertSame('https://ws-paylands.paynopain.com/v1', $container->getParameter('paymentsuite.paylands.api_url'));
+        $this->assertSame('PaylandsBundle:Paylands:view.html.twig', $container->getParameter('paymentsuite.paylands.view_template'));
+        $this->assertSame('PaylandsBundle:Paylands:scripts.html.twig', $container->getParameter('paymentsuite.paylands.scripts_template'));
+        $this->assertNull($container->getParameter('paymentsuite.paylands.validation_service'));
+        $paymentServices = [
+            'EUR' => 'eur-service',
+            'USD' => 'usd-service',
+        ];
+        $this->assertSame($paymentServices, $container->getParameter('paymentsuite.paylands.payment_services'));
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.paylands.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paylands.route_success')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.route_failure'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paylands.route_failure')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.route_card_invalid'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paylands.route_card_invalid')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.paylands.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.paylands.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.paylands.form_factory'));
+        $this->assertSame(PaylandsFormFactory::class, $container->getDefinition('paymentsuite.paylands.form_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.manager'));
+        $this->assertSame(PaylandsManager::class, $container->getDefinition('paymentsuite.paylands.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.view_renderer'));
+        $this->assertSame(PaylandsViewRenderer::class, $container->getDefinition('paymentsuite.paylands.view_renderer')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.currency_service_resolver'));
+        $this->assertSame(PaylandsCurrencyServiceResolver::class, $container->getDefinition('paymentsuite.paylands.currency_service_resolver')->getClass());
+
+        //Api Services
+        $this->assertTrue($container->has('paymentsuite.paylands.api.discovery_proxy'));
+        $this->assertSame(DiscoveryProxy::class, $container->getDefinition('paymentsuite.paylands.api.discovery_proxy')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.request_factory'));
+        $this->assertSame(RequestFactory::class, $container->getDefinition('paymentsuite.paylands.api.request_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.client_factory'));
+        $this->assertSame(ClientFactory::class, $container->getDefinition('paymentsuite.paylands.api.client_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.client_default'));
+        $this->assertSame(Client::class, $container->getDefinition('paymentsuite.paylands.api.client_default')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.adapter'));
+        $this->assertSame(PaylandsApiAdapter::class, $container->getDefinition('paymentsuite.paylands.api.adapter')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.paylands.settings_provider_default'));
+        $this->assertSame(PaylandsSettingsProviderDefault::class, $container->getDefinition('paymentsuite.paylands.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.paylands.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.paylands.settings_provider');
+        $this->assertSame('paymentsuite.paylands.settings_provider_default', $settingsProvider->__toString());
+    }
+
+    public function testLoadCustomSettingsProvider()
+    {
+        $configs = [
+            'paylands' => [
+                'settings_provider' => 'test.dummy_settings_provider',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_failure' => [
+                    'route' => 'test-route-failure',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_card_invalid' => [
+                    'route' => 'test-route-card-invalid',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new PaylandsExtension();
+        $extension->load($configs, $container);
+
+        //Parameters
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.api_key'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.signature'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.operative'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.sandbox'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.fallback_template_uuid'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.i18n_template_uuids'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.api_url'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.view_template'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.scripts_template'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.validation_service'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paylands.payment_services'));
+
+        $this->assertSame('dummy_api_key', $container->getParameter('paymentsuite.paylands.api_key'));
+        $this->assertSame('dummy_signature', $container->getParameter('paymentsuite.paylands.signature'));
+        $this->assertSame('AUTHORIZATION', $container->getParameter('paymentsuite.paylands.operative'));
+        $this->assertFalse($container->getParameter('paymentsuite.paylands.sandbox'));
+        $this->assertSame('default', $container->getParameter('paymentsuite.paylands.fallback_template_uuid'));
+        $this->assertSame([], $container->getParameter('paymentsuite.paylands.i18n_template_uuids'));
+        $this->assertSame('https://ws-paylands.paynopain.com/v1', $container->getParameter('paymentsuite.paylands.api_url'));
+        $this->assertSame('PaylandsBundle:Paylands:view.html.twig', $container->getParameter('paymentsuite.paylands.view_template'));
+        $this->assertSame('PaylandsBundle:Paylands:scripts.html.twig', $container->getParameter('paymentsuite.paylands.scripts_template'));
+        $this->assertNull($container->getParameter('paymentsuite.paylands.validation_service'));
+        $paymentServices = [
+            'EUR' => 'dummy_service'
+        ];
+        $this->assertSame($paymentServices, $container->getParameter('paymentsuite.paylands.payment_services'));
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.paylands.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paylands.route_success')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.route_failure'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paylands.route_failure')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.route_card_invalid'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paylands.route_card_invalid')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.paylands.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.paylands.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.paylands.form_factory'));
+        $this->assertSame(PaylandsFormFactory::class, $container->getDefinition('paymentsuite.paylands.form_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.manager'));
+        $this->assertSame(PaylandsManager::class, $container->getDefinition('paymentsuite.paylands.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.view_renderer'));
+        $this->assertSame(PaylandsViewRenderer::class, $container->getDefinition('paymentsuite.paylands.view_renderer')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.currency_service_resolver'));
+        $this->assertSame(PaylandsCurrencyServiceResolver::class, $container->getDefinition('paymentsuite.paylands.currency_service_resolver')->getClass());
+
+        //Api Services
+        $this->assertTrue($container->has('paymentsuite.paylands.api.discovery_proxy'));
+        $this->assertSame(DiscoveryProxy::class, $container->getDefinition('paymentsuite.paylands.api.discovery_proxy')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.request_factory'));
+        $this->assertSame(RequestFactory::class, $container->getDefinition('paymentsuite.paylands.api.request_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.client_factory'));
+        $this->assertSame(ClientFactory::class, $container->getDefinition('paymentsuite.paylands.api.client_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.client_default'));
+        $this->assertSame(Client::class, $container->getDefinition('paymentsuite.paylands.api.client_default')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paylands.api.adapter'));
+        $this->assertSame(PaylandsApiAdapter::class, $container->getDefinition('paymentsuite.paylands.api.adapter')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.paylands.settings_provider_default'));
+        $this->assertSame(PaylandsSettingsProviderDefault::class, $container->getDefinition('paymentsuite.paylands.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.paylands.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.paylands.settings_provider');
+        $this->assertSame('test.dummy_settings_provider', $settingsProvider->__toString());
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsEventDispatcherTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsEventDispatcherTest.php
@@ -34,7 +34,7 @@ class PaylandsEventDispatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function notifyCardValid()
     {
-        $paylandsMethod = new PaylandsMethod();
+        $paylandsMethod = new PaylandsMethod('test-name');
 
         /** @var EventDispatcherInterface|ObjectProphecy $eventDispatcher */
         $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsManagerTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsManagerTest.php
@@ -37,7 +37,7 @@ class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function paymentWorksFineAndCreatesAPaymentTransaction()
     {
-        $paymentMethod = new PaylandsMethod();
+        $paymentMethod = new PaylandsMethod('test-name');
 
         $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
         $paymentBridge
@@ -93,7 +93,7 @@ class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function paymentWorksFineOnlyCardValidation()
     {
-        $paymentMethod = new PaylandsMethod();
+        $paymentMethod = new PaylandsMethod('test-name');
 
         $paymentMethod->setOnlyTokenizeCard(true);
 
@@ -152,7 +152,7 @@ class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function paymentThrowsExceptionIfCardNotValid()
     {
-        $paymentMethod = new PaylandsMethod();
+        $paymentMethod = new PaylandsMethod('test-name');
 
         $paymentMethod->setOnlyTokenizeCard(true);
 
@@ -211,7 +211,7 @@ class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function paymentThrowsExceptionIfCardValidEventThrowsException()
     {
-        $paymentMethod = new PaylandsMethod();
+        $paymentMethod = new PaylandsMethod('test-name');
 
         $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
         $paymentBridge
@@ -268,7 +268,7 @@ class PaylandsManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function paymentThrowsExceptionIfTransactionFails()
     {
-        $paymentMethod = new PaylandsMethod();
+        $paymentMethod = new PaylandsMethod('test-name');
 
         $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
         $paymentBridge

--- a/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsSettingsProviderDefaultTest.php
+++ b/src/PaymentSuite/PaylandsBundle/Tests/Services/PaylandsSettingsProviderDefaultTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PaymentSuite\PaypalWebCheckoutBundle\Tests\Services;
+
+use PaymentSuite\PaylandsBundle\Services\PaylandsSettingsProviderDefault;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutSettingsProviderDefault;
+use PHPUnit\Framework\TestCase;
+
+class PaylandsSettingsProviderDefaultTest extends TestCase
+{
+    public function testCreateService()
+    {
+        $apiKey = 'api-key';
+        $apiSignature = 'me';
+        $i18nCardTemplates = [
+            'en' => 'template'
+        ];
+        $paymentServices = [
+            'currency' => 'EUR',
+            'service' => 'service-id'
+        ];
+
+        $validationService = 'validation-id';
+
+        $service = new PaylandsSettingsProviderDefault(
+            $apiKey,
+            $apiSignature,
+            $paymentServices,
+            $i18nCardTemplates,
+            $validationService
+        );
+
+        $this->assertEquals($apiKey, $service->getApiKey());
+        $this->assertEquals($apiSignature, $service->getApiSignature());
+        $this->assertEquals($paymentServices, $service->getPaymentServices());
+        $this->assertEquals($validationService, $service->getValidationService());
+        $this->assertEquals($i18nCardTemplates, $service->getI18nCardTemplates());
+        $this->assertEquals('Paylands', $service->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/PaylandsBundle/composer.json
+++ b/src/PaymentSuite/PaylandsBundle/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^5.5|^7.0",
+        "symfony/expression-language": "^2.8|^3.0",
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony/form": "^2.8|^3.0",
         "symfony/config": "^2.8|^3.0",

--- a/src/PaymentSuite/PaymentCoreBundle/DependencyInjection/Abstracts/AbstractPaymentSuiteConfiguration.php
+++ b/src/PaymentSuite/PaymentCoreBundle/DependencyInjection/Abstracts/AbstractPaymentSuiteConfiguration.php
@@ -52,4 +52,39 @@ abstract class AbstractPaymentSuiteConfiguration implements ConfigurationInterfa
 
         return $node;
     }
+
+    /**
+     * Adds common configuration for every payment method given a root node.
+     *
+     * @param NodeDefinition $rootNode
+     */
+    final protected function addSettingsProviderConfiguration(NodeDefinition $rootNode)
+    {
+        $rootNode
+            ->beforeNormalization()
+                ->ifTrue(function ($v) {
+                    return isset($v['settings_provider']) && 'default' != $v['settings_provider'];
+                })
+                ->then(function ($v) {
+                    return static::setDefaultSettings($v);
+                })
+            ->end()
+            ->children()
+                ->scalarNode('settings_provider')
+                    ->defaultValue('default')
+                ->end()
+            ->end();
+    }
+
+    /**
+     * Sets default values for required custom settings.
+     *
+     * @param array $config
+     *
+     * @return array
+     */
+    protected function setDefaultSettings($config)
+    {
+        return $config;
+    }
 }

--- a/src/PaymentSuite/PaymentCoreBundle/DependencyInjection/Abstracts/AbstractPaymentSuiteExtension.php
+++ b/src/PaymentSuite/PaymentCoreBundle/DependencyInjection/Abstracts/AbstractPaymentSuiteExtension.php
@@ -109,4 +109,23 @@ abstract class AbstractPaymentSuiteExtension extends Extension
             );
         }
     }
+
+    /**
+     * Defines the alias for the settings provider services.
+     *
+     * @param ContainerBuilder $container
+     * @param string           $paymentName
+     * @param string           $settingsProviderConfiguration
+     */
+    protected function addSettingsProvider(
+        ContainerBuilder $container,
+        $paymentName,
+        $settingsProviderConfiguration
+    ) {
+        $serviceId = 'default' == $settingsProviderConfiguration
+            ? "paymentsuite.$paymentName.settings_provider_default"
+            : $settingsProviderConfiguration;
+
+        $container->setAlias("paymentsuite.$paymentName.settings_provider", $serviceId);
+    }
 }

--- a/src/PaymentSuite/PaymentCoreBundle/DependencyInjection/PaymentCoreExtension.php
+++ b/src/PaymentSuite/PaymentCoreBundle/DependencyInjection/PaymentCoreExtension.php
@@ -28,6 +28,7 @@ use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPayment
  */
 class PaymentCoreExtension extends AbstractPaymentSuiteExtension
 {
+
     /**
      * {@inheritdoc}
      */

--- a/src/PaymentSuite/PaymentCoreBundle/PaymentCoreBundle.php
+++ b/src/PaymentSuite/PaymentCoreBundle/PaymentCoreBundle.php
@@ -17,7 +17,6 @@ namespace PaymentSuite\PaymentCoreBundle;
 
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-
 use PaymentSuite\PaymentCoreBundle\DependencyInjection\PaymentCoreExtension;
 
 /**

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,6 @@
 namespace PaymentSuite\PaypalWebCheckoutBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-
 use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteConfiguration;
 
 /**
@@ -41,16 +40,28 @@ class Configuration extends AbstractPaymentSuiteConfiguration
                 ->booleanNode('debug')
                     ->defaultTrue()
                 ->end()
-                ->booleanNode('api_endpoint')
+                ->scalarNode('api_endpoint')
                     ->defaultValue('https://www.paypal.com/cgi-bin/webscr')
                 ->end()
-                ->booleanNode('sandbox_api_endpoint')
+                ->scalarNode('sandbox_api_endpoint')
                     ->defaultValue('https://www.sandbox.paypal.com/cgi-bin/webscr')
                 ->end()
                 ->append($this->addRouteConfiguration('payment_success'))
                 ->append($this->addRouteConfiguration('payment_cancel'))
             ->end();
 
+        $this->addSettingsProviderConfiguration($rootNode);
+
         return $treeBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setDefaultSettings($config)
+    {
+        $config['business'] = 'dummy@paypal.com';
+
+        return $config;
     }
 }

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/DependencyInjection/PaypalWebCheckoutExtension.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/DependencyInjection/PaypalWebCheckoutExtension.php
@@ -18,7 +18,6 @@ namespace PaymentSuite\PaypalWebCheckoutBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
-
 use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteExtension;
 
 /**
@@ -57,8 +56,14 @@ class PaypalWebCheckoutExtension extends AbstractPaymentSuiteExtension
             ]
         );
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('services.yml');
+
+        $this->addSettingsProvider(
+            $container,
+            'paypal_web_checkout',
+            $config['settings_provider']
+        );
     }
 }

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/PaypalWebCheckoutEmptyMethod.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/PaypalWebCheckoutEmptyMethod.php
@@ -23,12 +23,27 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 class PaypalWebCheckoutEmptyMethod implements PaymentMethodInterface
 {
     /**
+     * @var string
+     */
+    private $paymentName;
+
+    /**
+     * PaypalWebCheckoutEmptyMethod constructor.
+     *
+     * @param string $paymentName
+     */
+    public function __construct($paymentName)
+    {
+        $this->paymentName = $paymentName;
+    }
+
+    /**
      * Return type of payment name.
      *
      * @return string
      */
     public function getPaymentName()
     {
-        return 'paypal_web_checkout';
+        return $this->paymentName;
     }
 }

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/PaypalWebCheckoutMethod.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/PaypalWebCheckoutMethod.php
@@ -23,7 +23,7 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
  * Mirrors Paypal IPN message issued when confirming a payment.
  * This class is used to wrap the message in a class
  *
- * @link   https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNandPDTVariables/#id091EB04C0HS
+ * @see   https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNandPDTVariables/#id091EB04C0HS
  */
 class PaypalWebCheckoutMethod implements PaymentMethodInterface
 {
@@ -372,7 +372,7 @@ class PaypalWebCheckoutMethod implements PaymentMethodInterface
      * @var string
      *
      * The merchant's original transaction identification number for the payment from the buyer,
-     * against which the case was registered.
+     * against which the case was registered
      */
     private $txnId;
 
@@ -384,11 +384,19 @@ class PaypalWebCheckoutMethod implements PaymentMethodInterface
     private $ipnTrackId;
 
     /**
+     * @var string
+     *
+     * Payment method name
+     */
+    private $paymentName;
+
+    /**
      * Initialize Paypal Method using an array which represents
      * the parameters coming from the IPN message as shown in.
      *
      * https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNandPDTVariables/#id091EAB0105Z
      *
+     * @param string $paymentName   Payment method name
      * @param float  $mcGross       Mc gross
      * @param string $paymentStatus Payment status
      * @param string $notifyVersion Notify version
@@ -409,6 +417,7 @@ class PaypalWebCheckoutMethod implements PaymentMethodInterface
      * @param string $ipnTrackId    Ipn track id
      */
     public function __construct(
+        $paymentName,
         $mcGross = null,
         $paymentStatus = null,
         $notifyVersion = null,
@@ -446,6 +455,7 @@ class PaypalWebCheckoutMethod implements PaymentMethodInterface
         $this->itemNumber = $itemNumber;
         $this->testIpn = $testIpn;
         $this->ipnTrackId = $ipnTrackId;
+        $this->paymentName = $paymentName;
     }
 
     /**
@@ -455,7 +465,7 @@ class PaypalWebCheckoutMethod implements PaymentMethodInterface
      */
     public function getPaymentName()
     {
-        return 'paypal_web_checkout';
+        return $this->paymentName;
     }
 
     /**

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Resources/config/services.yml
@@ -6,26 +6,33 @@ services:
     paymentsuite.paypal_web_checkout.form_type_factory:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutFormTypeFactory
         arguments:
-            - "@paymentsuite.paypal_web_checkout.url_factory"
-            - "@paymentsuite.bridge"
-            - "@form.factory"
-            - %paymentsuite.paypal_web_checkout.business%
+            - '@paymentsuite.paypal_web_checkout.url_factory'
+            - '@paymentsuite.bridge'
+            - '@form.factory'
+            - '@paymentsuite.paypal_web_checkout.settings_provider'
 
     paymentsuite.paypal_web_checkout.manager:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutManager
         arguments:
-            - "@paymentsuite.paypal_web_checkout.url_factory"
-            - "@paymentsuite.paypal_web_checkout.form_type_factory"
-            - "@paymentsuite.paypal_web_checkout.method_factory"
-            - "@paymentsuite.bridge"
-            - "@paymentsuite.event_dispatcher"
+            - '@paymentsuite.paypal_web_checkout.url_factory'
+            - '@paymentsuite.paypal_web_checkout.form_type_factory'
+            - '@paymentsuite.paypal_web_checkout.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
 
     paymentsuite.paypal_web_checkout.url_factory:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutUrlFactory
         arguments:
-            - "@paymentsuite.paypal_web_checkout.routes"
-            - "@router"
-            - %paymentsuite.paypal_web_checkout.api_endpoint%
+            - '@paymentsuite.paypal_web_checkout.routes'
+            - '@router'
+            - '%paymentsuite.paypal_web_checkout.api_endpoint%'
 
     paymentsuite.paypal_web_checkout.method_factory:
         class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutMethodFactory
+        arguments:
+            - '@paymentsuite.paypal_web_checkout.settings_provider'
+
+    paymentsuite.paypal_web_checkout.settings_provider_default:
+        class: PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutSettingsProviderDefault
+        arguments:
+            - '%paymentsuite.paypal_web_checkout.business%'

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Services/Interfaces/PaypalWebCheckoutSettingsProviderInterface.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Services/Interfaces/PaypalWebCheckoutSettingsProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PaymentSuite\PaypalWebCheckoutBundle\Services\Interfaces;
+
+use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
+
+interface PaypalWebCheckoutSettingsProviderInterface extends PaymentMethodInterface
+{
+    /**
+     * Gets paypal business account email.
+     *
+     * @return string
+     */
+    public function getBusiness();
+}

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Services/PaypalWebCheckoutFormTypeFactory.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Services/PaypalWebCheckoutFormTypeFactory.php
@@ -15,9 +15,9 @@
 
 namespace PaymentSuite\PaypalWebCheckoutBundle\Services;
 
+use PaymentSuite\PaypalWebCheckoutBundle\Services\Interfaces\PaypalWebCheckoutSettingsProviderInterface;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormView;
-
 use PaymentSuite\PaymentCoreBundle\Services\interfaces\PaymentBridgeInterface;
 use PaymentSuite\PaypalWebCheckoutBundle\Exception\CurrencyNotSupportedException;
 
@@ -48,36 +48,38 @@ class PaypalWebCheckoutFormTypeFactory
     private $paymentBridge;
 
     /**
-     * @var string
+     * @var PaypalWebCheckoutSettingsProviderInterface
      *
-     * Merchant identifier
+     * Settings provider
      */
-    private $business;
+    private $settingsProvider;
 
     /**
      * Formtype construct method.
      *
-     * @param PaypalWebCheckoutUrlFactory $urlFactory    URL Factory service
-     * @param PaymentBridgeInterface      $paymentBridge Payment bridge
-     * @param FormFactory                 $formFactory   Form factory
-     * @param string                      $business      merchant code
+     * @param PaypalWebCheckoutUrlFactory                $urlFactory       URL Factory service
+     * @param PaymentBridgeInterface                     $paymentBridge    Payment bridge
+     * @param FormFactory                                $formFactory      Form factory
+     * @param PaypalWebCheckoutSettingsProviderInterface $settingsProvider Settings provider
      */
     public function __construct(
         PaypalWebCheckoutUrlFactory $urlFactory,
         PaymentBridgeInterface $paymentBridge,
         FormFactory $formFactory,
-        $business
+        PaypalWebCheckoutSettingsProviderInterface $settingsProvider
     ) {
         $this->urlFactory = $urlFactory;
         $this->paymentBridge = $paymentBridge;
         $this->formFactory = $formFactory;
-        $this->business = $business;
+        $this->settingsProvider = $settingsProvider;
     }
 
     /**
      * Builds form given return, success and fail urls.
      *
      * @return FormView
+     *
+     * @throws CurrencyNotSupportedException
      */
     public function buildForm()
     {
@@ -129,7 +131,7 @@ class PaypalWebCheckoutFormTypeFactory
             ->setAction($this->urlFactory->getApiEndpoint())
             ->setMethod('POST')
             ->add('business', 'hidden', [
-                'data' => $this->business,
+                'data' => $this->settingsProvider->getBusiness(),
             ])
             ->add('return', 'hidden', [
                 'data' => $successReturnUrl,
@@ -168,13 +170,13 @@ class PaypalWebCheckoutFormTypeFactory
 
         foreach ($itemsData as $orderLine) {
             $formBuilder
-                ->add('item_name_' . $iteration, 'hidden', [
+                ->add('item_name_'.$iteration, 'hidden', [
                     'data' => $orderLine['item_name'],
                 ])
-                ->add('amount_' . $iteration, 'hidden', [
+                ->add('amount_'.$iteration, 'hidden', [
                     'data' => $orderLine['amount'],
                 ])
-                ->add('quantity_' . $iteration, 'hidden', [
+                ->add('quantity_'.$iteration, 'hidden', [
                     'data' => $orderLine['quantity'],
                 ]);
             ++$iteration;

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Services/PaypalWebCheckoutMethodFactory.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Services/PaypalWebCheckoutMethodFactory.php
@@ -17,6 +17,7 @@ namespace PaymentSuite\PaypalWebCheckoutBundle\Services;
 
 use PaymentSuite\PaypalWebCheckoutBundle\PaypalWebCheckoutEmptyMethod;
 use PaymentSuite\PaypalWebCheckoutBundle\PaypalWebCheckoutMethod;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\Interfaces\PaypalWebCheckoutSettingsProviderInterface;
 
 /**
  * Class PaypalWebCheckoutMethodFactory.
@@ -24,13 +25,28 @@ use PaymentSuite\PaypalWebCheckoutBundle\PaypalWebCheckoutMethod;
 class PaypalWebCheckoutMethodFactory
 {
     /**
+     * @var PaypalWebCheckoutSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
+     * PaypalWebCheckoutMethodFactory constructor.
+     *
+     * @param PaypalWebCheckoutSettingsProviderInterface $settingsProvider
+     */
+    public function __construct(PaypalWebCheckoutSettingsProviderInterface $settingsProvider)
+    {
+        $this->settingsProvider = $settingsProvider;
+    }
+
+    /**
      * Create a new empty PaypalWebCheckoutEmptyMethod instance.
      *
      * @return PaypalWebCheckoutEmptyMethod
      */
     public function createEmpty()
     {
-        return new PaypalWebCheckoutEmptyMethod();
+        return new PaypalWebCheckoutEmptyMethod($this->settingsProvider->getPaymentName());
     }
 
     /**
@@ -81,6 +97,7 @@ class PaypalWebCheckoutMethodFactory
         $ipnTrackId = null
     ) {
         return new PaypalWebCheckoutMethod(
+            $this->settingsProvider->getPaymentName(),
             $mcGross,
             $paymentStatus,
             $notifyVersion,

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Services/PaypalWebCheckoutSettingsProviderDefault.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Services/PaypalWebCheckoutSettingsProviderDefault.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PaymentSuite\PaypalWebCheckoutBundle\Services;
+
+use PaymentSuite\PaypalWebCheckoutBundle\Services\Interfaces\PaypalWebCheckoutSettingsProviderInterface;
+
+class PaypalWebCheckoutSettingsProviderDefault implements PaypalWebCheckoutSettingsProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $business;
+
+    /**
+     * PaypalWebCheckoutSettingsProviderDefault constructor.
+     *
+     * @param string $business
+     */
+    public function __construct($business)
+    {
+        $this->business = $business;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBusiness()
+    {
+        return $this->business;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaymentName()
+    {
+        return 'paypal_web_checkout';
+    }
+}

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PaymentSuite\PaypalWebCheckoutBundle\Tests\DependencyInjection;
+
+use PaymentSuite\PaypalWebCheckoutBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class ConfigurationTest extends TestCase
+{
+    public function testBusinessMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('business');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testPaymentSuccessMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['business'] = 'dummy@paypal.com';
+        unset($inputConfig['payment_success']);
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('payment_success');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testPaymentCancelMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['business'] = 'dummy@paypal.com';
+        unset($inputConfig['payment_cancel']);
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('payment_cancel');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testBusinessMightNotBeSetIfCustomSettingsProviderIsSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['settings_provider'] = 'dummy_service_id';
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+        $expectedConfig['settings_provider'] = 'dummy_service_id';
+        $expectedConfig['business'] = 'dummy@paypal.com';
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['business'] = 'dummy@paypal.com';
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+        $expectedConfig['business'] = 'dummy@paypal.com';
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    private function getRoutesConfiguration()
+    {
+        return [
+            'payment_success' => [
+                'route' => 'test-route-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+            'payment_cancel' => [
+                'route' => 'test-route-failure',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+    }
+
+    private function getDefaultConfiguration()
+    {
+        $config = $this->getRoutesConfiguration();
+        $config['settings_provider'] = 'default';
+        $config['debug'] = true;
+        $config['api_endpoint'] = 'https://www.paypal.com/cgi-bin/webscr';
+        $config['sandbox_api_endpoint'] = 'https://www.sandbox.paypal.com/cgi-bin/webscr';
+
+        return $config;
+    }
+}

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Tests/DependencyInjection/PaypalWebCheckoutExtensionTest.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Tests/DependencyInjection/PaypalWebCheckoutExtensionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace PaymentSuite\PaypalWebCheckoutBundle\Tests\DependencyInjection;
+
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRoute;
+use PaymentSuite\PaypalWebCheckoutBundle\Controller\PaymentController;
+use PaymentSuite\PaypalWebCheckoutBundle\Controller\ProcessController;
+use PaymentSuite\PaypalWebCheckoutBundle\DependencyInjection\PaypalWebCheckoutExtension;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutFormTypeFactory;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutManager;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutMethodFactory;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutSettingsProviderDefault;
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutUrlFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class PaypalWebCheckoutExtensionTest extends TestCase
+{
+    public function testLoadDefaults()
+    {
+        $configs = [
+            'paypal_web_checkout' => [
+                'settings_provider' => 'default',
+                'business' => 'test@paypal.com',
+                'debug' => true,
+                'api_endpoint' => 'https://www.paypal.com/cgi-bin/webscr',
+                'sandbox_api_endpoint' => 'https://www.sandbox.paypal.com/cgi-bin/webscr',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_cancel' => [
+                    'route' => 'test-route-failure',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new PaypalWebCheckoutExtension();
+        $extension->load($configs, $container);
+
+        //Parameters
+        $this->assertTrue($container->hasParameter('paymentsuite.paypal_web_checkout.business'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paypal_web_checkout.api_endpoint'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paypal_web_checkout.debug'));
+
+        $this->assertSame('test@paypal.com', $container->getParameter('paymentsuite.paypal_web_checkout.business'));
+        $this->assertSame(true, $container->getParameter('paymentsuite.paypal_web_checkout.debug'));
+        $this->assertSame('https://www.sandbox.paypal.com/cgi-bin/webscr', $container->getParameter('paymentsuite.paypal_web_checkout.api_endpoint'));
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paypal_web_checkout.route_success')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.route_cancel'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paypal_web_checkout.route_cancel')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.paypal_web_checkout.payment_controller')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.process_controller'));
+        $this->assertSame(ProcessController::class, $container->getDefinition('paymentsuite.paypal_web_checkout.process_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.form_type_factory'));
+        $this->assertSame(PaypalWebCheckoutFormTypeFactory::class, $container->getDefinition('paymentsuite.paypal_web_checkout.form_type_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.manager'));
+        $this->assertSame(PaypalWebCheckoutManager::class, $container->getDefinition('paymentsuite.paypal_web_checkout.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.url_factory'));
+        $this->assertSame(PaypalWebCheckoutUrlFactory::class, $container->getDefinition('paymentsuite.paypal_web_checkout.url_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.method_factory'));
+        $this->assertSame(PaypalWebCheckoutMethodFactory::class, $container->getDefinition('paymentsuite.paypal_web_checkout.method_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.settings_provider_default'));
+        $this->assertSame(PaypalWebCheckoutSettingsProviderDefault::class, $container->getDefinition('paymentsuite.paypal_web_checkout.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.paypal_web_checkout.settings_provider');
+        $this->assertSame('paymentsuite.paypal_web_checkout.settings_provider_default', $settingsProvider->__toString());
+    }
+
+    public function testLoadCustomSettingsProvider()
+    {
+        $configs = [
+            'paypal_web_checkout' => [
+                'settings_provider' => 'test.dummy_settings_provider',
+                'debug' => true,
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_cancel' => [
+                    'route' => 'test-route-failure',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new PaypalWebCheckoutExtension();
+        $extension->load($configs, $container);
+
+        //Parameters
+        $this->assertTrue($container->hasParameter('paymentsuite.paypal_web_checkout.business'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paypal_web_checkout.api_endpoint'));
+        $this->assertTrue($container->hasParameter('paymentsuite.paypal_web_checkout.debug'));
+
+        $this->assertSame('dummy@paypal.com', $container->getParameter('paymentsuite.paypal_web_checkout.business'));
+        $this->assertSame(true, $container->getParameter('paymentsuite.paypal_web_checkout.debug'));
+        $this->assertSame('https://www.sandbox.paypal.com/cgi-bin/webscr', $container->getParameter('paymentsuite.paypal_web_checkout.api_endpoint'));
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paypal_web_checkout.route_success')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.route_cancel'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.paypal_web_checkout.route_cancel')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.paypal_web_checkout.payment_controller')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.process_controller'));
+        $this->assertSame(ProcessController::class, $container->getDefinition('paymentsuite.paypal_web_checkout.process_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.form_type_factory'));
+        $this->assertSame(PaypalWebCheckoutFormTypeFactory::class, $container->getDefinition('paymentsuite.paypal_web_checkout.form_type_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.manager'));
+        $this->assertSame(PaypalWebCheckoutManager::class, $container->getDefinition('paymentsuite.paypal_web_checkout.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.url_factory'));
+        $this->assertSame(PaypalWebCheckoutUrlFactory::class, $container->getDefinition('paymentsuite.paypal_web_checkout.url_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.method_factory'));
+        $this->assertSame(PaypalWebCheckoutMethodFactory::class, $container->getDefinition('paymentsuite.paypal_web_checkout.method_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.settings_provider_default'));
+        $this->assertSame(PaypalWebCheckoutSettingsProviderDefault::class, $container->getDefinition('paymentsuite.paypal_web_checkout.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.paypal_web_checkout.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.paypal_web_checkout.settings_provider');
+        $this->assertSame('test.dummy_settings_provider', $settingsProvider->__toString());
+    }
+}

--- a/src/PaymentSuite/PaypalWebCheckoutBundle/Tests/Services/PaypalWebCheckoutSettingsProviderDefaultTest.php
+++ b/src/PaymentSuite/PaypalWebCheckoutBundle/Tests/Services/PaypalWebCheckoutSettingsProviderDefaultTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PaymentSuite\PaypalWebCheckoutBundle\Tests\Services;
+
+use PaymentSuite\PaypalWebCheckoutBundle\Services\PaypalWebCheckoutSettingsProviderDefault;
+use PHPUnit\Framework\TestCase;
+
+class PaypalWebCheckoutSettingsProviderDefaultTest extends TestCase
+{
+    public function testCreateService()
+    {
+        $business = 'test@paypal.com';
+        $service = new PaypalWebCheckoutSettingsProviderDefault($business);
+
+        $this->assertNotNull($service);
+        $this->assertEquals($business, $service->getBusiness());
+        $this->assertEquals('paypal_web_checkout', $service->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/RedsysBundle/DependencyInjection/Configuration.php
@@ -26,6 +26,10 @@ use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPayment
  */
 class Configuration extends AbstractPaymentSuiteConfiguration
 {
+    const GATEWAY_TERMINAL = '001';
+
+    const GATEWAY_URL = 'https://sis.redsys.es/sis/realizarPago';
+
     /**
      * {@inheritdoc}
      */
@@ -44,8 +48,12 @@ class Configuration extends AbstractPaymentSuiteConfiguration
                     ->isRequired()
                     ->cannotBeEmpty()
                 ->end()
+                ->scalarNode('terminal')
+                    ->defaultValue(self::GATEWAY_TERMINAL)
+                    ->cannotBeEmpty()
+                ->end()
                 ->scalarNode('url')
-                    ->defaultValue('https://sis.redsys.es/sis/realizarPago')
+                    ->defaultValue(self::GATEWAY_URL)
                 ->end()
                 ->append($this->addRouteConfiguration('payment_success'))
                 ->append($this->addRouteConfiguration('payment_failure'))

--- a/src/PaymentSuite/RedsysBundle/DependencyInjection/RedsysExtension.php
+++ b/src/PaymentSuite/RedsysBundle/DependencyInjection/RedsysExtension.php
@@ -43,6 +43,7 @@ class RedsysExtension extends AbstractPaymentSuiteExtension
                 'merchant_code' => $config['merchant_code'],
                 'secret_key' => $config['secret_key'],
                 'url' => $config['url'],
+                'terminal' => $config['terminal']
             ]
         );
 

--- a/src/PaymentSuite/RedsysBundle/Exception/DecodeParametersException.php
+++ b/src/PaymentSuite/RedsysBundle/Exception/DecodeParametersException.php
@@ -13,15 +13,13 @@
  * @author Marc Morera <yuhu@mmoreram.com>
  */
 
-namespace PaymentSuite\PaylandsBundle\Exception;
+namespace PaymentSuite\RedsysBundle\Exception;
 
 use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
 
 /**
- * Class CreateFormException.
- *
- * @author Santi Garcia <sgarcia@wearemarketing.com>, <sangarbe@gmail.com>
+ * Class DecodeParametersException.
  */
-class CreateFormException extends PaymentException
+class DecodeParametersException extends PaymentException
 {
 }

--- a/src/PaymentSuite/RedsysBundle/RedsysMethod.php
+++ b/src/PaymentSuite/RedsysBundle/RedsysMethod.php
@@ -23,290 +23,133 @@ use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
 final class RedsysMethod implements PaymentMethodInterface
 {
     /**
-     * @var string
+     * @var array
      *
-     * Transaction response
+     * Decoded dsMerchantParameters array
      */
-    private $dsResponse;
+    private $dsMerchantParametersDecoded;
 
     /**
      * @var string
      *
-     * Transaction date
+     * Base64 encoded json string representation of payment parameters
      */
-    private $dsDate;
+    private $dsMerchantParameters;
 
     /**
      * @var string
      *
-     * Transaction hour
+     * Transmission version type
      */
-    private $dsHour;
+    private $dsSignatureVersion;
 
     /**
-     *  @var string
+     * @var string
      *
-     * Transaction secure payment
+     * Encrypted payment signature
      */
-    private $dsSecurePayment;
+    private $dsSignature;
 
     /**
-     *  @var string
-     *
-     * Transaction card country
+     * RedsysMethod constructor.
      */
-    private $dsCardCountry;
-
-    /**
-     *  @var string
-     *
-     * Transaction authorisation code
-     */
-    private $dsAuthorisationCode;
-
-    /**
-     *  @var string
-     *
-     * Transaction consumer language
-     */
-    private $dsConsumerLanguage;
-
-    /**
-     *  @var string
-     *
-     * Transaction card type
-     */
-    private $dsCardType;
-
-    /**
-     *  @var string
-     *
-     * Transaction order
-     */
-    private $dsOrder;
-
-    /**
-     * Get Redsys method name.
-     *
-     * @return string Payment name
-     */
-    public function getPaymentName()
+    private function __construct()
     {
-        return 'Redsys';
     }
 
     /**
-     * set Response code.
-     *
-     * @param string $dsResponse Response code
-     *
-     * @return RedsysMethod self Object
+     * @return RedsysMethod
      */
-    public function setDsResponse($dsResponse)
+    public static function createEmpty()
     {
-        $this->dsResponse = $dsResponse;
-
-        return $this;
+        return new self();
     }
 
     /**
-     * Get Response code.
+     * @param array  $dsMerchantParametersDecoded
+     * @param string $dsMerchantParameters
+     * @param string $dsSignatureVersion
+     * @param string $dsSignature
      *
-     * @return string Response code
+     * @return RedsysMethod
      */
-    public function getDsResponse()
-    {
-        return $this->dsResponse;
-    }
-    /**
-     * set Authorisation code.
-     *
-     * @param string $dsAuthorisationCode
-     *
-     * @return RedsysMethod self Object
-     */
-    public function setDsAuthorisationCode($dsAuthorisationCode)
-    {
-        $this->dsAuthorisationCode = $dsAuthorisationCode;
+    public static function create(
+        $dsMerchantParametersDecoded,
+        $dsMerchantParameters,
+        $dsSignatureVersion,
+        $dsSignature
+    ) {
+        $instance = new self();
 
-        return $this;
-    }
+        $instance->dsMerchantParametersDecoded = $dsMerchantParametersDecoded;
+        $instance->dsMerchantParameters = $dsMerchantParameters;
+        $instance->dsSignatureVersion = $dsSignatureVersion;
+        $instance->dsSignature = $dsSignature;
 
-    /**
-     * Get Authorisation code.
-     *
-     * @return string
-     */
-    public function getDsAuthorisationCode()
-    {
-        return $this->dsAuthorisationCode;
+        return $instance;
     }
 
     /**
-     *  Set Card country.
-     *
-     * @param string $dsCardCountry
-     *
-     * @return RedsysMethod self Object
+     * @return array|null
      */
-    public function setDsCardCountry($dsCardCountry)
+    public function getDsMerchantParametersDecoded()
     {
-        $this->dsCardCountry = $dsCardCountry;
-
-        return $this;
+        return $this->dsMerchantParametersDecoded;
     }
 
     /**
-     * Get Card country.
-     *
-     * @return string
+     * @return string|null
      */
-    public function getDsCardCountry()
+    public function getDsMerchantParameters()
     {
-        return $this->dsCardCountry;
+        return $this->dsMerchantParameters;
     }
 
     /**
-     * Set Card type.
-     *
-     * @param string $dsCardType
-     *
-     * @return RedsysMethod self Object
+     * @return string|null
      */
-    public function setDsCardType($dsCardType)
+    public function getDsSignatureVersion()
     {
-        $this->dsCardType = $dsCardType;
-
-        return $this;
+        return $this->dsSignatureVersion;
     }
 
     /**
-     * Get Card type.
-     *
-     * @return string
+     * @return string|null
      */
-    public function getDsCardType()
+    public function getDsSignature()
     {
-        return $this->dsCardType;
+        return $this->dsSignature;
     }
 
     /**
-     * Set consumer language.
-     *
-     * @param string $dsConsumerLanguage
-     *
-     * @return RedsysMethod self Object
+     * @return bool
      */
-    public function setDsConsumerLanguage($dsConsumerLanguage)
+    public function isTransactionSuccessful()
     {
-        $this->dsConsumerLanguage = $dsConsumerLanguage;
+        if(is_null($this->dsMerchantParametersDecoded)){
+            return false;
+        }
 
-        return $this;
+        $dsResponse = intval($this->dsMerchantParametersDecoded['Ds_Response']);
+
+        return $dsResponse >= 0 && $dsResponse <= 99;
     }
 
     /**
-     * Get Consumer language.
-     *
-     * @return string
-     */
-    public function getDsConsumerLanguage()
-    {
-        return $this->dsConsumerLanguage;
-    }
-
-    /**
-     * Set date.
-     *
-     * @param string $dsDate
-     *
-     * @return RedsysMethod self Object
-     */
-    public function setDsDate($dsDate)
-    {
-        $this->dsDate = $dsDate;
-
-        return $this;
-    }
-
-    /**
-     * Get date.
-     *
-     * @return string
-     */
-    public function getDsDate()
-    {
-        return $this->dsDate;
-    }
-
-    /**
-     * Set hour.
-     *
-     * @param string $dsHour
-     *
-     * @return RedsysMethod self Object
-     */
-    public function setDsHour($dsHour)
-    {
-        $this->dsHour = $dsHour;
-
-        return $this;
-    }
-
-    /**
-     * Get Hour.
-     *
-     * @return string
-     */
-    public function getDsHour()
-    {
-        return $this->dsHour;
-    }
-
-    /**
-     * Set Secure payment.
-     *
-     * @param string $dsSecurePayment
-     *
-     * @return RedsysMethod self Object
-     */
-    public function setDsSecurePayment($dsSecurePayment)
-    {
-        $this->dsSecurePayment = $dsSecurePayment;
-
-        return $this;
-    }
-
-    /**
-     * Get Secure payment.
-     *
-     * @return string
-     */
-    public function getDsSecurePayment()
-    {
-        return $this->dsSecurePayment;
-    }
-
-    /**
-     * Set Order payment.
-     *
-     * @param string $dsOrder
-     *
-     * @return RedsysMethod self Object
-     */
-    public function setDsOrder($dsOrder)
-    {
-        $this->dsOrder = $dsOrder;
-
-        return $this;
-    }
-
-    /**
-     * Get Order payment.
-     *
-     * @return string
+     * @return string|null
      */
     public function getDsOrder()
     {
-        return $this->dsOrder;
+        return $this->dsMerchantParametersDecoded['Ds_Order'];
+    }
+
+    /**
+     * Returns the method's type name.
+     *
+     * @return string
+     */
+    public function getPaymentName()
+    {
+        return 'redsys';
     }
 }

--- a/src/PaymentSuite/RedsysBundle/RedsysSignature.php
+++ b/src/PaymentSuite/RedsysBundle/RedsysSignature.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle;
+
+/**
+ * Class RedsysSignature.
+ */
+class RedsysSignature
+{
+    /**
+     * @var string
+     */
+    private $data;
+
+    /**
+     * RedsysSignature constructor.
+     *
+     * @param string $data
+     */
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @param RedsysSignature $signature
+     *
+     * @return bool
+     */
+    public function match(RedsysSignature $signature)
+    {
+        return $this->data === $signature->data;
+    }
+
+    public function __toString()
+    {
+        return $this->data;
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Resources/config/controllers.yml
+++ b/src/PaymentSuite/RedsysBundle/Resources/config/controllers.yml
@@ -6,19 +6,19 @@ services:
     paymentsuite.redsys.payment_controller:
         class: PaymentSuite\RedsysBundle\Controller\PaymentController
         arguments:
-            - @paymentsuite.redsys.manager
-            - @templating
+            - '@paymentsuite.redsys.manager'
+            - '@templating'
 
     paymentsuite.redsys.response_controller:
         class: PaymentSuite\RedsysBundle\Controller\ResponseController
         arguments:
-            - @paymentsuite.redsys.routes
-            - @router
+            - '@paymentsuite.redsys.routes'
+            - '@router'
 
     paymentsuite.redsys.result_controller:
         class: PaymentSuite\RedsysBundle\Controller\ResultController
         arguments:
-            - @paymentsuite.redsys.manager
-            - @paymentsuite.redsys.routes
-            - @paymentsuite.bridge
-            - @router
+            - '@paymentsuite.redsys.manager'
+            - '@paymentsuite.redsys.routes'
+            - '@paymentsuite.bridge'
+            - '@router'

--- a/src/PaymentSuite/RedsysBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/RedsysBundle/Resources/config/services.yml
@@ -6,26 +6,38 @@ services:
     paymentsuite.redsys.manager:
         class: PaymentSuite\RedsysBundle\Services\RedsysManager
         arguments:
-            - @paymentsuite.redsys.form_type_builder
-            - @paymentsuite.redsys.method_factory
-            - @paymentsuite.bridge
-            - @paymentsuite.event_dispatcher
-            - %paymentsuite.redsys.secret_key%
+            - '@paymentsuite.redsys.form_type_builder'
+            - '@paymentsuite.redsys.method_factory'
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.event_dispatcher'
+            - '@paymentsuite.redsys.order_transformer'
 
     paymentsuite.redsys.form_type_builder:
         class: PaymentSuite\RedsysBundle\Services\RedsysFormTypeBuilder
         arguments:
-            - @paymentsuite.bridge
-            - @paymentsuite.redsys.url_factory
-            - @form.factory
-            - %paymentsuite.redsys.merchant_code%
-            - %paymentsuite.redsys.secret_key%
-            - %paymentsuite.redsys.url%
+            - '@paymentsuite.bridge'
+            - '@paymentsuite.redsys.url_factory'
+            - '@paymentsuite.redsys.signature_factory'
+            - '@form.factory'
+            - '@paymentsuite.redsys.order_transformer'
+            - '%paymentsuite.redsys.merchant_code%'
+            - '%paymentsuite.redsys.url%'
+            - '%paymentsuite.redsys.terminal%'
 
     paymentsuite.redsys.url_factory:
         class: PaymentSuite\RedsysBundle\Services\RedsysUrlFactory
         arguments:
-            - @router
+            - '@router'
 
     paymentsuite.redsys.method_factory:
         class: PaymentSuite\RedsysBundle\Services\RedsysMethodFactory
+        arguments:
+            - '@paymentsuite.redsys.signature_factory'
+
+    paymentsuite.redsys.signature_factory:
+        class: PaymentSuite\RedsysBundle\Services\RedsysSignatureFactory
+        arguments:
+            - '%paymentsuite.redsys.secret_key%'
+
+    paymentsuite.redsys.order_transformer:
+        class: PaymentSuite\RedsysBundle\Services\RedsysOrderTransformer

--- a/src/PaymentSuite/RedsysBundle/Services/Interfaces/RedsysOrderTransformerInterface.php
+++ b/src/PaymentSuite/RedsysBundle/Services/Interfaces/RedsysOrderTransformerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Services\Interfaces;
+
+interface RedsysOrderTransformerInterface
+{
+    public function transform($orderId);
+
+    public function reverseTransform($dsOrder);
+}

--- a/src/PaymentSuite/RedsysBundle/Services/RedsysEncoder.php
+++ b/src/PaymentSuite/RedsysBundle/Services/RedsysEncoder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Services;
+
+/**
+ * Class RedsysEncoder.
+ */
+final class RedsysEncoder
+{
+    public static function encode($params)
+    {
+        return base64_encode(json_encode($params));
+    }
+
+    public static function decode($params)
+    {
+        return json_decode(base64_decode(self::normalize($params)), true);
+    }
+
+    public static function normalize($value)
+    {
+        return strtr($value, '-_', '+/');
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Services/RedsysFormTypeBuilder.php
+++ b/src/PaymentSuite/RedsysBundle/Services/RedsysFormTypeBuilder.php
@@ -15,9 +15,10 @@
 
 namespace PaymentSuite\RedsysBundle\Services;
 
+use PaymentSuite\RedsysBundle\Services\Interfaces\RedsysOrderTransformerInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormView;
-
 use PaymentSuite\RedsysBundle\Exception\CurrencyNotSupportedException;
 use PaymentSuite\RedsysBundle\Services\Interfaces\PaymentBridgeRedsysInterface;
 
@@ -57,174 +58,84 @@ class RedsysFormTypeBuilder
     /**
      * @var string
      *
-     * Secret key
-     */
-    private $secretKey;
-
-    /**
-     * @var string
-     *
      * Url
      */
     private $url;
 
     /**
+     * @var string
+     *
+     * Terminal id
+     */
+    private $terminal;
+    /**
+     * @var RedsysSignatureFactory
+     */
+    private $signatureFactory;
+    /**
+     * @var RedsysOrderTransformerInterface
+     */
+    private $redsysOrderTransformer;
+
+    /**
      * construct.
      *
-     * @param PaymentBridgeRedsysInterface $paymentBridge Payment bridge
-     * @param RedsysUrlFactory             $urlFactory    URL Factory service
-     * @param FormFactory                  $formFactory   Form factory
-     * @param string                       $merchantCode  merchant code
-     * @param string                       $secretKey     secret key
-     * @param string                       $url           gateway url
+     * @param PaymentBridgeRedsysInterface    $paymentBridge          Payment bridge
+     * @param RedsysUrlFactory                $urlFactory             URL Factory service
+     * @param RedsysSignatureFactory          $signatureFactory       Signature factory service
+     * @param FormFactory                     $formFactory            Form factory
+     * @param RedsysOrderTransformerInterface $redsysOrderTransformer Redsys order transformer
+     * @param string                          $merchantCode           merchant code
+     * @param string                          $url                    gateway url
+     * @param $terminal
      */
     public function __construct(
         PaymentBridgeRedsysInterface $paymentBridge,
         RedsysUrlFactory $urlFactory,
+        RedsysSignatureFactory $signatureFactory,
         FormFactory $formFactory,
+        RedsysOrderTransformerInterface $redsysOrderTransformer,
         $merchantCode,
-        $secretKey,
-        $url
+        $url,
+        $terminal
     ) {
         $this->paymentBridge = $paymentBridge;
         $this->urlFactory = $urlFactory;
         $this->formFactory = $formFactory;
         $this->merchantCode = $merchantCode;
-        $this->secretKey = $secretKey;
         $this->url = $url;
+        $this->terminal = $terminal;
+        $this->signatureFactory = $signatureFactory;
+        $this->redsysOrderTransformer = $redsysOrderTransformer;
     }
 
     /**
      * Builds form given return, success and fail urls.
      *
      * @return FormView
+     *
+     * @throws CurrencyNotSupportedException
      */
     public function buildForm()
     {
-        $orderId = $this
-            ->paymentBridge
-            ->getOrderId();
+        $merchantParameters = $this->buildParameters();
 
-        $extraData = $this->paymentBridge->getExtraData();
         $formBuilder = $this
             ->formFactory
             ->createNamedBuilder(null);
 
-        if (array_key_exists('transaction_type', $extraData)) {
-            $Ds_Merchant_TransactionType = $extraData['transaction_type'];
-        } else {
-            $Ds_Merchant_TransactionType = '0';
-        }
-
-        /**
-         * Creates the return route for Redsys.
-         */
-        $Ds_Merchant_MerchantURL = $this
-            ->urlFactory
-            ->getReturnRedsysUrl();
-
-        /**
-         * Creates the return route, when coming back
-         * from Redsys web checkout and proccess is Ok.
-         */
-        $Ds_Merchant_UrlOK = $this
-            ->urlFactory
-            ->getReturnUrlOkForOrderId($orderId);
-
-        /**
-         * Creates the cancel payment route, when coming back
-         * from Redsys web checkout and proccess is error.
-         */
-        $Ds_Merchant_UrlKO = $this
-            ->urlFactory
-            ->getReturnUrlKoForOrderId($orderId);
-
-        /**
-         * Creates the merchant signature.
-         */
-        $Ds_Merchant_Amount = $this->paymentBridge->getAmount();
-        $Ds_Merchant_Order = $this->formatOrderNumber(
-            $this
-                ->paymentBridge
-                ->getOrderNumber()
-        );
-        $Ds_Merchant_MerchantCode = $this->merchantCode;
-        $Ds_Merchant_Currency = $this->getCurrencyCodeByIso($this->paymentBridge->getCurrency());
-        $Ds_Merchant_MerchantSignature = $this->shopSignature(
-            $Ds_Merchant_Amount,
-            $Ds_Merchant_Order,
-            $Ds_Merchant_MerchantCode,
-            $Ds_Merchant_Currency,
-            $Ds_Merchant_TransactionType,
-            $Ds_Merchant_MerchantURL,
-            $this->secretKey
-        );
-
-        $Ds_Merchant_Terminal = $extraData['terminal'];
-
         $formBuilder
             ->setAction($this->url)
             ->setMethod('POST')
-            ->add('Ds_Merchant_Amount', 'hidden', [
-                'data' => $Ds_Merchant_Amount,
-            ])
-            ->add('Ds_Merchant_MerchantSignature', 'hidden', [
-                'data' => $Ds_Merchant_MerchantSignature,
-            ])
-            ->add('Ds_Merchant_MerchantCode', 'hidden', [
-                'data' => $this->merchantCode,
-            ])
-            ->add('Ds_Merchant_Currency', 'hidden', [
-                'data' => $Ds_Merchant_Currency,
-            ])
-            ->add('Ds_Merchant_Terminal', 'hidden', [
-                'data' => $Ds_Merchant_Terminal,
-            ])
-            ->add('Ds_Merchant_Order', 'hidden', [
-                'data' => $Ds_Merchant_Order,
-            ])
-            ->add('Ds_Merchant_MerchantURL', 'hidden', [
-                'data' => $Ds_Merchant_MerchantURL,
-            ])
-            ->add('Ds_Merchant_UrlOK', 'hidden', [
-                'data' => $Ds_Merchant_UrlOK,
-            ])
-            ->add('Ds_Merchant_UrlKO', 'hidden', [
-                'data' => $Ds_Merchant_UrlKO,
-            ]);
-
-        /**
-         * Optional form fields.
-         */
-        if (array_key_exists('transaction_type', $extraData)) {
-            $formBuilder->add('Ds_Merchant_TransactionType', 'hidden', [
-                'data' => $Ds_Merchant_TransactionType,
-            ]);
-        }
-
-        if (array_key_exists('product_description', $extraData)) {
-            $formBuilder->add('Ds_Merchant_ProductDescription', 'hidden', [
-                'data' => $extraData['product_description'],
-            ]);
-        }
-
-        if (array_key_exists('merchant_titular', $extraData)) {
-            $formBuilder->add('Ds_Merchant_Titular', 'hidden', [
-                'data' => $extraData['merchant_titular'],
-            ]);
-        }
-
-        if (array_key_exists('merchant_name', $extraData)) {
-            $formBuilder->add('Ds_Merchant_MerchantName', 'hidden', [
-                'data' => $extraData['merchant_name'],
-            ]);
-        }
-
-        if (array_key_exists('merchant_data', $extraData)) {
-            $formBuilder->add('Ds_Merchant_MerchantData', 'hidden', [
-                'data' => $extraData['merchant_data'],
-            ]);
-        }
+            ->add('Ds_SignatureVersion', HiddenType::class, array(
+                'data' => 'HMAC_SHA256_V1',
+            ))
+            ->add('Ds_MerchantParameters', HiddenType::class, array(
+                'data' => RedsysEncoder::encode($merchantParameters),
+            ))
+            ->add('Ds_Signature', HiddenType::class, array(
+                'data' => (string) $this->signatureFactory->createFromMerchantParameters($merchantParameters),
+            ));
 
         return $formBuilder
             ->getForm()
@@ -232,36 +143,52 @@ class RedsysFormTypeBuilder
     }
 
     /**
-     * Creates signature to be sent to Redsys.
+     * Returns an array of gateway payment parameters.
      *
-     * @param string $amount          Amount
-     * @param string $order           Order number
-     * @param string $merchantCode    Merchant code
-     * @param string $currency        Currency
-     * @param string $transactionType Transaction type
-     * @param string $merchantURL     Merchant url
-     * @param string $secret          Secret key
+     * @return array
      *
-     * @return string Signature
+     * @throws CurrencyNotSupportedException
      */
-    private function shopSignature(
-        $amount,
-        $order,
-        $merchantCode,
-        $currency,
-        $transactionType,
-        $merchantURL,
-        $secret
-    ) {
-        return strtoupper(sha1(implode('', [
-            $amount,
-            $order,
-            $merchantCode,
-            $currency,
-            $transactionType,
-            $merchantURL,
-            $secret,
-        ])));
+    private function buildParameters()
+    {
+        $orderId = $this
+            ->paymentBridge
+            ->getOrderId();
+
+        $extraData = $this->paymentBridge->getExtraData();
+
+        $parameters = array(
+            'Ds_Merchant_TransactionType' => isset($extraData['transaction_type']) ? $extraData['transaction_type'] : 0,
+            'Ds_Merchant_MerchantURL' => $this->urlFactory->getReturnRedsysUrl(),
+            'Ds_Merchant_UrlOK' => $this->urlFactory->getReturnUrlOkForOrderId($orderId),
+            'Ds_Merchant_UrlKO' => $this->urlFactory->getReturnUrlKoForOrderId($orderId),
+            'Ds_Merchant_Amount' => (string) $this->paymentBridge->getAmount(),
+            'Ds_Merchant_Order' => $this->redsysOrderTransformer->transform($orderId),
+            'Ds_Merchant_MerchantCode' => $this->merchantCode,
+            'Ds_Merchant_Currency' => $this->getCurrencyCodeByIso($this->paymentBridge->getCurrency()),
+            'Ds_Merchant_Terminal' => $this->terminal,
+        );
+
+        /*
+         * Optional parameters.
+         */
+        if (array_key_exists('product_description', $extraData)) {
+            $parameters['Ds_Merchant_ProductDescription'] = $extraData['product_description'];
+        }
+
+        if (array_key_exists('merchant_titular', $extraData)) {
+            $parameters['Ds_Merchant_Titular'] = $extraData['merchant_titular'];
+        }
+
+        if (array_key_exists('merchant_name', $extraData)) {
+            $parameters['Ds_Merchant_MerchantName'] = $extraData['merchant_name'];
+        }
+
+        if (array_key_exists('merchant_data', $extraData)) {
+            $parameters['Ds_Merchant_MerchantData'] = $extraData['merchant_data'];
+        }
+
+        return $parameters;
     }
 
     /**
@@ -309,26 +236,5 @@ class RedsysFormTypeBuilder
             default:
                 throw new CurrencyNotSupportedException();
         }
-    }
-
-    /**
-     * Formats order number to be Redsys compliant.
-     *
-     * @param string $orderNumber Order number
-     *
-     * @return string $orderNumber
-     *
-     * @todo Check that start with 4 numbers and that at least is 12 chars long
-     */
-    private function formatOrderNumber($orderNumber)
-    {
-        $length = strlen($orderNumber);
-        $minLength = 4;
-
-        if ($length < $minLength) {
-            $orderNumber = str_pad($orderNumber, $minLength, '0', STR_PAD_LEFT);
-        }
-
-        return $orderNumber;
     }
 }

--- a/src/PaymentSuite/RedsysBundle/Services/RedsysManager.php
+++ b/src/PaymentSuite/RedsysBundle/Services/RedsysManager.php
@@ -19,9 +19,11 @@ use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
 use PaymentSuite\PaymentCoreBundle\Exception\PaymentOrderNotFoundException;
 use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
 use PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher;
+use PaymentSuite\RedsysBundle\Exception\CurrencyNotSupportedException;
 use PaymentSuite\RedsysBundle\Exception\InvalidSignatureException;
 use PaymentSuite\RedsysBundle\Exception\ParameterNotReceivedException;
-use PaymentSuite\RedsysBundle\RedsysMethod;
+use PaymentSuite\RedsysBundle\Services\Interfaces\RedsysOrderTransformerInterface;
+use Symfony\Component\Form\FormView;
 
 /**
  * Redsys manager.
@@ -38,7 +40,7 @@ class RedsysManager
     /**
      * @var RedsysMethodFactory
      *
-     * RedsysMethod factory
+     * Redsys method factory
      */
     private $redsysMethodFactory;
 
@@ -57,49 +59,50 @@ class RedsysManager
     private $paymentEventDispatcher;
 
     /**
-     * @var string
+     * @var RedsysOrderTransformerInterface
      *
-     * Secret key
+     * Redsys order transformer
      */
-    private $secretKey;
+    private $redsysOrderTransformer;
 
     /**
      * Construct method for redsys manager.
      *
-     * @param RedsysFormTypeBuilder  $redsysFormTypeBuilder  Form Type Builder
-     * @param RedsysMethodFactory    $redsysMethodFactory    RedsysMethod factory
-     * @param PaymentBridgeInterface $paymentBridge          Payment Bridge
-     * @param PaymentEventDispatcher $paymentEventDispatcher Event dispatcher
-     * @param string                 $secretKey              Secret Key
+     * @param RedsysFormTypeBuilder           $redsysFormTypeBuilder  Form Type Builder
+     * @param RedsysMethodFactory             $redsysMethodFactory    RedsysMethod factory
+     * @param PaymentBridgeInterface          $paymentBridge          Payment Bridge
+     * @param PaymentEventDispatcher          $paymentEventDispatcher Event dispatcher
+     * @param RedsysOrderTransformerInterface $redsysOrderTransformer
      */
     public function __construct(
         RedsysFormTypeBuilder $redsysFormTypeBuilder,
         RedsysMethodFactory $redsysMethodFactory,
         PaymentBridgeInterface $paymentBridge,
         PaymentEventDispatcher $paymentEventDispatcher,
-        $secretKey
+        RedsysOrderTransformerInterface $redsysOrderTransformer
     ) {
         $this->redsysFormTypeBuilder = $redsysFormTypeBuilder;
         $this->redsysMethodFactory = $redsysMethodFactory;
         $this->paymentBridge = $paymentBridge;
         $this->paymentEventDispatcher = $paymentEventDispatcher;
-        $this->secretKey = $secretKey;
+        $this->redsysOrderTransformer = $redsysOrderTransformer;
     }
 
     /**
      * Creates form view for Redsys payment.
      *
-     * @return \Symfony\Component\Form\FormView
+     * @return FormView
      *
      * @throws PaymentOrderNotFoundException
+     * @throws CurrencyNotSupportedException
      */
     public function processPayment()
     {
         $redsysMethod = $this
             ->redsysMethodFactory
-            ->create();
+            ->createEmpty();
 
-        /**
+        /*
          * At this point, order must be created given a cart, and placed in PaymentBridge.
          *
          * So, $this->paymentBridge->getOrder() must return an object
@@ -111,14 +114,14 @@ class RedsysManager
                 $redsysMethod
             );
 
-        /**
+        /*
          * Order Not found Exception must be thrown just here.
          */
         if (!$this->paymentBridge->getOrder()) {
             throw new PaymentOrderNotFoundException();
         }
 
-        /**
+        /*
          * Order exists right here.
          */
         $this
@@ -146,57 +149,20 @@ class RedsysManager
      */
     public function processResult(array $parameters)
     {
-        $this->checkResultParameters($parameters);
+        $redsysMethod = $this
+            ->redsysMethodFactory
+            ->createFromResultParameters($parameters);
 
-        $redsysMethod = new RedsysMethod();
-
-        $dsSignature = $parameters['Ds_Signature'];
-        $dsResponse = $parameters['Ds_Response'];
-        $dsAmount = $parameters['Ds_Amount'];
-        $dsOrder = $parameters['Ds_Order'];
-        $dsMerchantCode = $parameters['Ds_MerchantCode'];
-        $dsCurrency = $parameters['Ds_Currency'];
-        $dsSecret = $this->secretKey;
-        $dsDate = $parameters['Ds_Date'];
-        $dsHour = $parameters['Ds_Hour'];
-        $dsSecurePayment = $parameters['Ds_SecurePayment'];
-        $dsCardCountry = $parameters['Ds_Card_Country'];
-        $dsAuthorisationCode = $parameters['Ds_AuthorisationCode'];
-        $dsConsumerLanguage = $parameters['Ds_ConsumerLanguage'];
-        $dsCardType = array_key_exists('Ds_Card_Type', $parameters)
-            ? $parameters['Ds_Card_Type']
-            : '';
-
-        if ($dsSignature != $this
-                ->expectedSignature(
-                    $dsAmount,
-                    $dsOrder,
-                    $dsMerchantCode,
-                    $dsCurrency,
-                    $dsResponse,
-                    $dsSecret
-                )
-        ) {
-            throw new InvalidSignatureException();
-        }
-
-        /**
-         * Adding transaction information to PaymentMethod.
-         *
-         * This information is only available in PaymentOrderSuccess event
+        /*
+         * Here PaymentBridge shouldn't have the order loaded, so we find it fromm parameters
          */
-        $redsysMethod
-            ->setDsResponse($dsResponse)
-            ->setDsAuthorisationCode($dsAuthorisationCode)
-            ->setDsCardCountry($dsCardCountry)
-            ->setDsCardType($dsCardType)
-            ->setDsConsumerLanguage($dsConsumerLanguage)
-            ->setDsDate($dsDate)
-            ->setDsHour($dsHour)
-            ->setDsSecurePayment($dsSecurePayment)
-            ->setDsOrder($dsOrder);
+        $orderId = $this->redsysOrderTransformer
+            ->reverseTransform($redsysMethod->getDsOrder());
 
-        /**
+        $this->paymentBridge
+            ->findOrder($orderId);
+
+        /*
          * Payment paid done.
          *
          * Paid process has ended ( No matters result )
@@ -208,13 +174,12 @@ class RedsysManager
                 $redsysMethod
             );
 
-        /**
+        /*
          * when a transaction is successful, $Ds_Response has a
          * value between 0 and 99.
          */
-        if (!$this->transactionSuccessful($dsResponse)) {
-
-            /**
+        if (!$redsysMethod->isTransactionSuccessful()) {
+            /*
              * Payment paid failed.
              *
              * Paid process has ended failed
@@ -229,7 +194,7 @@ class RedsysManager
             throw new PaymentException();
         }
 
-        /**
+        /*
          * Payment paid successfully.
          *
          * Paid process has ended successfully
@@ -242,85 +207,5 @@ class RedsysManager
             );
 
         return $this;
-    }
-
-    /**
-     * Returns true if the transaction was successful.
-     *
-     * @param string $dsResponse Response code
-     *
-     * @return bool
-     */
-    private function transactionSuccessful($dsResponse)
-    {
-        /**
-         * When a transaction is successful, $Ds_Response has a value
-         * between 0 and 99.
-         */
-
-        return intval($dsResponse) >= 0 && intval($dsResponse) <= 99;
-    }
-
-    /**
-     * Returns the expected signature.
-     *
-     * @param string $amount       Amount
-     * @param string $order        Order
-     * @param string $merchantCode Merchant Code
-     * @param string $currency     Currency
-     * @param string $response     Response code
-     * @param string $secret       Secret
-     *
-     * @return string Signature
-     */
-    private function expectedSignature(
-        $amount,
-        $order,
-        $merchantCode,
-        $currency,
-        $response,
-        $secret
-    ) {
-        return strtoupper(sha1(implode('', [
-            $amount,
-            $order,
-            $merchantCode,
-            $currency,
-            $response,
-            $secret,
-        ])));
-    }
-
-    /**
-     * Checks that all the required parameters are received.
-     *
-     * @param array $parameters Parameters
-     *
-     * @throws ParameterNotReceivedException Parameters missing
-     */
-    private function checkResultParameters(array $parameters)
-    {
-        $elementsMissing = array_diff([
-            'Ds_Date',
-            'Ds_Hour',
-            'Ds_Amount',
-            'Ds_Currency',
-            'Ds_Order',
-            'Ds_MerchantCode',
-            'Ds_Terminal',
-            'Ds_Signature',
-            'Ds_Response',
-            'Ds_TransactionType',
-            'Ds_SecurePayment',
-            'Ds_Card_Country',
-            'Ds_AuthorisationCode',
-            'Ds_ConsumerLanguage',
-        ], $parameters);
-
-        if (!empty($elementsMissing)) {
-            throw new ParameterNotReceivedException(
-                implode(', ', $elementsMissing)
-            );
-        }
     }
 }

--- a/src/PaymentSuite/RedsysBundle/Services/RedsysOrderTransformer.php
+++ b/src/PaymentSuite/RedsysBundle/Services/RedsysOrderTransformer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Services;
+
+use PaymentSuite\RedsysBundle\Services\Interfaces\RedsysOrderTransformerInterface;
+
+class RedsysOrderTransformer implements RedsysOrderTransformerInterface
+{
+    public function transform($orderId)
+    {
+        $orderNumber = (string) $orderId;
+
+        $length = strlen($orderNumber);
+        $minLength = 4;
+
+        if ($length < $minLength) {
+            $orderNumber = str_pad($orderNumber, $minLength, '0', STR_PAD_LEFT);
+        }
+
+        $orderNumber .= 'T'.strrev(time());
+        $orderNumber = substr($orderNumber, 0, 12);
+
+        return $orderNumber;
+    }
+
+    public function reverseTransform($dsOrder)
+    {
+        $chunks = explode('T', $dsOrder);
+
+        return (int) $chunks[0];
+    }
+
+
+}

--- a/src/PaymentSuite/RedsysBundle/Services/RedsysSignatureFactory.php
+++ b/src/PaymentSuite/RedsysBundle/Services/RedsysSignatureFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Services;
+
+use PaymentSuite\RedsysBundle\RedsysSignature;
+
+class RedsysSignatureFactory
+{
+    /**
+     * @var string
+     */
+    private $secretKey;
+
+    /**
+     * RedsysSignatureFactory constructor.
+     *
+     * @param string $secretKey
+     */
+    public function __construct($secretKey)
+    {
+        $this->secretKey = $secretKey;
+    }
+
+    /**
+     * @param string $signature
+     *
+     * @return RedsysSignature
+     */
+    public function createFromResultString($signature)
+    {
+        $data = RedsysEncoder::normalize($signature);
+
+        return $this->create($data);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string
+     */
+    public function createFromMerchantParameters($parameters)
+    {
+        return $this->createFromParameters($parameters, 'Ds_Merchant_Order');
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return string
+     */
+    public function createFromResultParameters($parameters)
+    {
+        return $this->createFromParameters($parameters, 'Ds_Order');
+    }
+
+    private function create($data)
+    {
+        return new RedsysSignature($data);
+    }
+
+    private function createFromParameters($parameters, $orderKey)
+    {
+        $key = $this->encrypt($parameters[$orderKey]);
+
+        $hash = $this->hash(RedsysEncoder::encode($parameters), $key);
+
+        return $this->create($hash);
+    }
+
+    private function encrypt($message)
+    {
+        $key = base64_decode($this->secretKey);
+
+        $bytes = array(0, 0, 0, 0, 0, 0, 0, 0);
+        $iv = implode(array_map('chr', $bytes));
+
+        if (strlen($message) % 8) {
+            $message = str_pad($message, strlen($message) + 8 - strlen($message) % 8, "\0");
+        }
+
+        return openssl_encrypt($message, 'DES-EDE3-CBC', $key, OPENSSL_NO_PADDING | OPENSSL_RAW_DATA, $iv);
+    }
+
+    private function hash($data, $key)
+    {
+        return base64_encode(hash_hmac('sha256', $data, $key, true));
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/Controller/ProcessPaymentTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/Controller/ProcessPaymentTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\Controller;
+
+use PaymentSuite\RedsysBundle\Services\Interfaces\PaymentBridgeRedsysInterface;
+use PaymentSuite\RedsysBundle\Services\RedsysEncoder;
+use PaymentSuite\RedsysBundle\Tests\app\RedsysKernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Form;
+
+/**
+ * Class ProcessPaymentTest.
+ */
+class ProcessPaymentTest extends WebTestCase
+{
+    private $client;
+
+    protected static function getKernelClass()
+    {
+        return RedsysKernel::class;
+    }
+
+
+    protected function setUp()
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testExecuteAction()
+    {
+        $container = $this->client->getContainer();
+
+        /** @var PaymentBridgeRedsysInterface $paymentBridge */
+        $paymentBridge = $container->get('paymentsuite.bridge');
+        $paymentBridge->setOrder(new \stdClass());
+
+        $crawler = $this->client->request('GET', '/payment/redsys/execute');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        /** @var Form $form */
+        $form = $crawler->children()->last()->children()->first()->form();
+
+        $this->assertEquals('https://sis.redsys.es/sis/realizarPago', $form->getUri());
+        $this->assertEquals('POST', $form->getMethod());
+
+        $this->assertTrue($form->has('Ds_SignatureVersion'));
+        $this->assertTrue($form->has('Ds_MerchantParameters'));
+        $this->assertTrue($form->has('Ds_Signature'));
+
+        $this->assertEquals('HMAC_SHA256_V1', $form->get('Ds_SignatureVersion')->getValue());
+        $this->assertNotEmpty($form->get('Ds_MerchantParameters')->getValue());
+        $this->assertNotEmpty($form->get('Ds_Signature')->getValue());
+    }
+
+    public function testSuccessAction()
+    {
+        $this->client->request('GET', '/payment/redsys/success?id=1');
+
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('/payment/redsys/success', $this->client->getResponse()->headers->get('Location'));
+    }
+
+    public function testFailureAction()
+    {
+        $this->client->request('GET', '/payment/redsys/failure?id=1');
+
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('/payment/redsys/failure', $this->client->getResponse()->headers->get('Location'));
+    }
+
+    public function testResultActionSuccess()
+    {
+        $container = $this->client->getContainer();
+
+        /** @var PaymentBridgeRedsysInterface $paymentBridge */
+        $paymentBridge = $container->get('paymentsuite.bridge');
+        $paymentBridge->setOrder(new \stdClass());
+
+        $resultParameters = [
+            'Ds_Order' => '1T54321',
+            'Ds_Response' => '0',
+        ];
+
+        $signature = $container->get('paymentsuite.redsys.signature_factory')->createFromResultParameters($resultParameters);
+
+        $parameters = [
+            'Ds_SignatureVersion' => 'HMAC_SHA256_V1',
+            'Ds_Signature' => (string) $signature,
+            'Ds_MerchantParameters' => RedsysEncoder::encode($resultParameters),
+        ];
+
+        $this->client->request('POST', '/payment/redsys/result', $parameters);
+
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('/payment/redsys/success', $this->client->getResponse()->headers->get('Location'));
+    }
+
+    public function testResultActionFailsIfInvalidSignature()
+    {
+        $resultParameters = [
+            'Ds_Order' => '1T54321',
+            'Ds_Response' => '0',
+        ];
+
+        $parameters = [
+            'Ds_SignatureVersion' => 'HMAC_SHA256_V1',
+            'Ds_Signature' => 'invalid-signature',
+            'Ds_MerchantParameters' => RedsysEncoder::encode($resultParameters),
+        ];
+
+        $this->client->request('POST', '/payment/redsys/result', $parameters);
+
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('/payment/redsys/failure', $this->client->getResponse()->headers->get('Location'));
+    }
+
+    public function testResultActionFailsIfInvalidResponse()
+    {
+        $resultParameters = [
+            'Ds_Order' => '1T54321',
+            'Ds_Response' => '100',
+        ];
+
+        $parameters = [
+            'Ds_SignatureVersion' => 'HMAC_SHA256_V1',
+            'Ds_Signature' => 'invalid-signature',
+            'Ds_MerchantParameters' => RedsysEncoder::encode($resultParameters),
+        ];
+
+        $this->client->request('POST', '/payment/redsys/result', $parameters);
+
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('/payment/redsys/failure', $this->client->getResponse()->headers->get('Location'));
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\DependencyInjection;
+
+use PaymentSuite\RedsysBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    public function testConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $config = [
+            'terminal' => '002',
+            'url' => '/some-url',
+            'merchant_code' => '1234567',
+            'secret_key' => 'test-key',
+            'payment_success' => [
+                'route' => 'test-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+            'payment_failure' => [
+                'route' => 'test-failure',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+
+        $normalized = $configTree->normalize($config);
+        $finalized = $configTree->finalize($normalized);
+
+        $this->assertEquals($config, $finalized);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $config = [
+            'merchant_code' => '1234567',
+            'secret_key' => 'test-key',
+            'payment_success' => [
+                'route' => 'test-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+            'payment_failure' => [
+                'route' => 'test-failure',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+
+        $normalized = $configTree->normalize($config);
+        $finalized = $configTree->finalize($normalized);
+
+        $expected = array_merge($config, [
+            'terminal' => '001',
+            'url' => 'https://sis.redsys.es/sis/realizarPago',
+        ]);
+
+        $this->assertEquals($expected, $finalized);
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/Fixtures/DummyPaymentBridge.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/Fixtures/DummyPaymentBridge.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\Fixtures;
+
+use PaymentSuite\RedsysBundle\Services\Interfaces\PaymentBridgeRedsysInterface;
+
+class DummyPaymentBridge implements PaymentBridgeRedsysInterface
+{
+    private $order;
+
+    public function setOrder($order)
+    {
+        $this->order = $order;
+    }
+
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    public function findOrder($orderId)
+    {
+        if(1 === $orderId){
+            return new \stdClass();
+        }
+
+        return null;
+    }
+
+    public function getOrderId()
+    {
+        return 1;
+    }
+
+    public function isOrderPaid()
+    {
+    }
+
+    public function getAmount()
+    {
+        return 9999;
+    }
+
+    public function getCurrency()
+    {
+        return 'EUR';
+    }
+
+    public function getExtraData()
+    {
+        return [];
+    }
+
+    public function getOrderNumber()
+    {
+        return '1T54321';
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/RedsysMethodTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/RedsysMethodTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests;
+
+use PaymentSuite\RedsysBundle\RedsysMethod;
+use PHPUnit\Framework\TestCase;
+
+class RedsysMethodTest extends TestCase
+{
+    public function testCreateEmpty()
+    {
+        $instance = RedsysMethod::createEmpty();
+
+        $this->assertEmpty($instance->getDsMerchantParameters());
+        $this->assertEmpty($instance->getDsMerchantParametersDecoded());
+        $this->assertEmpty($instance->getDsSignatureVersion());
+        $this->assertEmpty($instance->getDsSignature());
+        $this->assertEmpty($instance->getDsOrder());
+    }
+
+    public function testCreate()
+    {
+        $order = '1234';
+        $dsMerchantParametersDecoded = [
+            'Ds_Order' => $order,
+            'Ds_Response' => '0',
+        ];
+        $dsMerchantParameters = 'dummyParameters';
+        $dsSignatureVersion = 'sha256';
+        $dsSignature = 'dummySignature';
+
+        $instance = RedsysMethod::create(
+            $dsMerchantParametersDecoded,
+            $dsMerchantParameters,
+            $dsSignatureVersion,
+            $dsSignature
+        );
+
+        $this->assertEquals($dsMerchantParameters, $instance->getDsMerchantParameters());
+        $this->assertEquals($dsMerchantParametersDecoded, $instance->getDsMerchantParametersDecoded());
+        $this->assertEquals($dsSignatureVersion, $instance->getDsSignatureVersion());
+        $this->assertEquals($dsSignature, $instance->getDsSignature());
+        $this->assertEquals($order, $instance->getDsOrder());
+    }
+
+    public function testIsTransactionSuccessfulReturnsFalseIfEmptyMethod()
+    {
+        $instance = RedsysMethod::createEmpty();
+
+        $this->assertFalse($instance->isTransactionSuccessful());
+    }
+
+    /**
+     * @dataProvider invalidResponseData
+     */
+    public function testIsTransactionSuccessfulReturnsFalse($value)
+    {
+        $instance = RedsysMethod::create(['Ds_Response' => $value], '', '', '');
+
+        $this->assertFalse($instance->isTransactionSuccessful());
+    }
+
+    /**
+     * @dataProvider validResponseData
+     */
+    public function testIsTransactionSuccessfulReturnsTrue($value)
+    {
+        $instance = RedsysMethod::create(['Ds_Response' => $value], '', '', '');
+
+        $this->assertTrue($instance->isTransactionSuccessful());
+    }
+
+    public function invalidResponseData()
+    {
+        return [
+            ['-1'],
+            ['100'],
+        ];
+    }
+
+    public function validResponseData()
+    {
+        return [
+            ['0'],
+            ['1'],
+            ['99'],
+            ['98'],
+        ];
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/RedsysSignatureTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/RedsysSignatureTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests;
+
+use PaymentSuite\RedsysBundle\RedsysSignature;
+use PHPUnit\Framework\TestCase;
+
+class RedsysSignatureTest extends TestCase
+{
+    public function testToString()
+    {
+        $signature = new RedsysSignature('12345');
+
+        $this->assertEquals('12345', $signature->__toString());
+    }
+
+    public function testMatch()
+    {
+        $signature = new RedsysSignature('12345');
+        $signatureEquals = new RedsysSignature('12345');
+        $signatureDifferent = new RedsysSignature('6789');
+
+        $this->assertTrue($signature->match($signatureEquals));
+        $this->assertFalse($signature->match($signatureDifferent));
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysManagerTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysManagerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\Services;
+
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentException;
+use PaymentSuite\PaymentCoreBundle\Exception\PaymentOrderNotFoundException;
+use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
+use PaymentSuite\PaymentCoreBundle\Services\PaymentEventDispatcher;
+use PaymentSuite\RedsysBundle\RedsysMethod;
+use PaymentSuite\RedsysBundle\Services\Interfaces\RedsysOrderTransformerInterface;
+use PaymentSuite\RedsysBundle\Services\RedsysFormTypeBuilder;
+use PaymentSuite\RedsysBundle\Services\RedsysManager;
+use PaymentSuite\RedsysBundle\Services\RedsysMethodFactory;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Form\Form;
+
+class RedsysManagerTest extends TestCase
+{
+    public function testProcessPayment()
+    {
+        $form = $this->prophesize(Form::class);
+        $redsysMethod = RedsysMethod::createEmpty();
+        $order = new \stdClass();
+
+        $redsysFormTypeBuilder = $this->prophesize(RedsysFormTypeBuilder::class);
+        $redsysFormTypeBuilder
+            ->buildForm()
+            ->shouldBeCalled()
+            ->willReturn($form->reveal());
+
+        $redsysMethodFactory = $this->prophesize(RedsysMethodFactory::class);
+        $redsysMethodFactory
+            ->createEmpty()
+            ->shouldBeCalled()
+            ->willReturn($redsysMethod);
+
+        $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
+        $paymentBridge
+            ->getOrder()
+            ->shouldBeCalled()
+            ->willReturn($order);
+
+        $paymentEventDispatcher = $this->prophesize(PaymentEventDispatcher::class);
+        $paymentEventDispatcher
+            ->notifyPaymentOrderLoad($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+        $paymentEventDispatcher
+            ->notifyPaymentOrderCreated($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+
+        $redsysOrderTransformer = $this->prophesize(RedsysOrderTransformerInterface::class);
+
+        $manager = new RedsysManager(
+            $redsysFormTypeBuilder->reveal(),
+            $redsysMethodFactory->reveal(),
+            $paymentBridge->reveal(),
+            $paymentEventDispatcher->reveal(),
+            $redsysOrderTransformer->reveal()
+        );
+
+        $builtForm = $manager->processPayment();
+
+        $this->assertSame($form->reveal(), $builtForm);
+    }
+
+    public function testProcessPaymentThrowsExceptionIfNotAnOrder()
+    {
+        $redsysMethod = RedsysMethod::createEmpty();
+
+        $redsysFormTypeBuilder = $this->prophesize(RedsysFormTypeBuilder::class);
+        $redsysFormTypeBuilder
+            ->buildForm()
+            ->shouldNotBeCalled();
+
+        $redsysMethodFactory = $this->prophesize(RedsysMethodFactory::class);
+        $redsysMethodFactory
+            ->createEmpty()
+            ->shouldBeCalled()
+            ->willReturn($redsysMethod);
+
+        $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
+        $paymentBridge
+            ->getOrder()
+            ->shouldBeCalled()
+            ->willReturn(null);
+
+        $paymentEventDispatcher = $this->prophesize(PaymentEventDispatcher::class);
+        $paymentEventDispatcher
+            ->notifyPaymentOrderLoad($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+        $paymentEventDispatcher
+            ->notifyPaymentOrderCreated(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $redsysOrderTransformer = $this->prophesize(RedsysOrderTransformerInterface::class);
+
+        $manager = new RedsysManager(
+            $redsysFormTypeBuilder->reveal(),
+            $redsysMethodFactory->reveal(),
+            $paymentBridge->reveal(),
+            $paymentEventDispatcher->reveal(),
+            $redsysOrderTransformer->reveal()
+        );
+
+        $this->expectException(PaymentOrderNotFoundException::class);
+
+        $manager->processPayment();
+    }
+
+    public function testProcessResult()
+    {
+        $order = '123';
+        $redsysMethod = RedsysMethod::create([
+            'Ds_Order' => $order,
+            'Ds_Response' => '0',
+        ], '', '', '');
+        $parameters = [];
+
+        $redsysFormTypeBuilder = $this->prophesize(RedsysFormTypeBuilder::class);
+
+        $redsysMethodFactory = $this->prophesize(RedsysMethodFactory::class);
+        $redsysMethodFactory
+            ->createFromResultParameters($parameters)
+            ->shouldBeCalled()
+            ->willReturn($redsysMethod);
+
+        $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
+        $paymentBridge
+            ->findOrder((int) $order)
+            ->shouldBeCalled();
+
+        $paymentEventDispatcher = $this->prophesize(PaymentEventDispatcher::class);
+        $paymentEventDispatcher
+            ->notifyPaymentOrderDone($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+        $paymentEventDispatcher
+            ->notifyPaymentOrderSuccess($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+
+        $redsysOrderTransformer = $this->prophesize(RedsysOrderTransformerInterface::class);
+        $redsysOrderTransformer
+            ->reverseTransform($order)
+            ->shouldBeCalled()
+            ->willReturn((int) $order);
+
+        $manager = new RedsysManager(
+            $redsysFormTypeBuilder->reveal(),
+            $redsysMethodFactory->reveal(),
+            $paymentBridge->reveal(),
+            $paymentEventDispatcher->reveal(),
+            $redsysOrderTransformer->reveal()
+        );
+
+        $manager->processResult($parameters);
+    }
+
+    public function testProcessResultThrowsExceptionIfNotTransactionSuccessful()
+    {
+        $order = '123';
+        $redsysMethod = RedsysMethod::create([
+            'Ds_Order' => $order,
+            'Ds_Response' => '100',
+        ], '', '', '');
+        $parameters = [];
+
+        $redsysFormTypeBuilder = $this->prophesize(RedsysFormTypeBuilder::class);
+
+        $redsysMethodFactory = $this->prophesize(RedsysMethodFactory::class);
+        $redsysMethodFactory
+            ->createFromResultParameters($parameters)
+            ->shouldBeCalled()
+            ->willReturn($redsysMethod);
+
+        $paymentBridge = $this->prophesize(PaymentBridgeInterface::class);
+        $paymentBridge
+            ->findOrder((int) $order)
+            ->shouldBeCalled();
+
+        $paymentEventDispatcher = $this->prophesize(PaymentEventDispatcher::class);
+        $paymentEventDispatcher
+            ->notifyPaymentOrderDone($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+        $paymentEventDispatcher
+            ->notifyPaymentOrderFail($paymentBridge->reveal(), $redsysMethod)
+            ->shouldBeCalled();
+
+        $redsysOrderTransformer = $this->prophesize(RedsysOrderTransformerInterface::class);
+        $redsysOrderTransformer
+            ->reverseTransform($order)
+            ->shouldBeCalled()
+            ->willReturn((int) $order);
+
+        $manager = new RedsysManager(
+            $redsysFormTypeBuilder->reveal(),
+            $redsysMethodFactory->reveal(),
+            $paymentBridge->reveal(),
+            $paymentEventDispatcher->reveal(),
+            $redsysOrderTransformer->reveal()
+        );
+
+        $this->expectException(PaymentException::class);
+
+        $manager->processResult($parameters);
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysMethodFactoryTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysMethodFactoryTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\Services;
+
+use PaymentSuite\RedsysBundle\Exception\DecodeParametersException;
+use PaymentSuite\RedsysBundle\Exception\InvalidSignatureException;
+use PaymentSuite\RedsysBundle\Exception\ParameterNotReceivedException;
+use PaymentSuite\RedsysBundle\RedsysMethod;
+use PaymentSuite\RedsysBundle\RedsysSignature;
+use PaymentSuite\RedsysBundle\Services\RedsysEncoder;
+use PaymentSuite\RedsysBundle\Services\RedsysMethodFactory;
+use PaymentSuite\RedsysBundle\Services\RedsysSignatureFactory;
+use PHPUnit\Framework\TestCase;
+
+class RedsysMethodFactoryTest extends TestCase
+{
+
+    public function testCreateEmpty()
+    {
+        $signatureFactory = $this->prophesize(RedsysSignatureFactory::class);
+
+        $factory = new RedsysMethodFactory($signatureFactory->reveal());
+
+        $method = $factory->createEmpty();
+
+        $this->assertInstanceOf(RedsysMethod::class, $method);
+        $this->assertNull($method->getDsMerchantParameters());
+        $this->assertNull($method->getDsMerchantParametersDecoded());
+        $this->assertNull($method->getDsSignature());
+        $this->assertNull($method->getDsSignatureVersion());
+    }
+
+    public function testCreateFromResultParametersThrowsExceptionIfMissingParameter()
+    {
+        $signatureFactory = $this->prophesize(RedsysSignatureFactory::class);
+
+        $factory = new RedsysMethodFactory($signatureFactory->reveal());
+
+        $parameters = [];
+
+        $this->expectException(ParameterNotReceivedException::class);
+
+        $factory->createFromResultParameters($parameters);
+    }
+
+    public function testCreateFromResultParametersThrowsExceptionIfInvalidParameters()
+    {
+        $signatureFactory = $this->prophesize(RedsysSignatureFactory::class);
+
+        $factory = new RedsysMethodFactory($signatureFactory->reveal());
+
+        $parameters = [
+            'Ds_MerchantParameters' => '',
+            'Ds_SignatureVersion' => '',
+            'Ds_Signature' => '',
+        ];
+
+        $this->expectException(DecodeParametersException::class);
+
+        $factory->createFromResultParameters($parameters);
+    }
+
+    public function testCreateFromResultParametersThrowsExceptionIfInvalidSignature()
+    {
+        $merchantParameters = [
+            'Ds_Order' => '1234'
+        ];
+
+        $receivedSignature = 'invalid';
+
+        $signatureFactory = $this->prophesize(RedsysSignatureFactory::class);
+        $signatureFactory
+            ->createFromResultParameters($merchantParameters)
+            ->shouldBeCalled()
+            ->willReturn(new RedsysSignature('signature'));
+
+        $signatureFactory
+            ->createFromResultString($receivedSignature)
+            ->shouldBeCalled()
+            ->willReturn(new RedsysSignature($receivedSignature));
+
+        $factory = new RedsysMethodFactory($signatureFactory->reveal());
+
+        $parameters = [
+            'Ds_MerchantParameters' => RedsysEncoder::encode($merchantParameters),
+            'Ds_SignatureVersion' => 'sha256',
+            'Ds_Signature' => $receivedSignature,
+        ];
+
+        $this->expectException(InvalidSignatureException::class);
+
+        $factory->createFromResultParameters($parameters);
+    }
+
+    public function testCreateFromResultParameters()
+    {
+        $merchantParameters = [
+            'Ds_Order' => '1234'
+        ];
+
+        $receivedSignature = 'valid';
+
+        $signatureFactory = $this->prophesize(RedsysSignatureFactory::class);
+        $signatureFactory
+            ->createFromResultParameters($merchantParameters)
+            ->shouldBeCalled()
+            ->willReturn(new RedsysSignature($receivedSignature));
+
+        $signatureFactory
+            ->createFromResultString($receivedSignature)
+            ->shouldBeCalled()
+            ->willReturn(new RedsysSignature($receivedSignature));
+
+        $factory = new RedsysMethodFactory($signatureFactory->reveal());
+
+        $encodedMerchantParameters = RedsysEncoder::encode($merchantParameters);
+
+        $parameters = [
+            'Ds_MerchantParameters' => $encodedMerchantParameters,
+            'Ds_SignatureVersion' => '',
+            'Ds_Signature' => $receivedSignature,
+        ];
+
+        $method = $factory->createFromResultParameters($parameters);
+
+        $this->assertInstanceOf(RedsysMethod::class, $method);
+        $this->assertEquals($encodedMerchantParameters, $method->getDsMerchantParameters());
+        $this->assertEquals($merchantParameters, $method->getDsMerchantParametersDecoded());
+        $this->assertEquals($receivedSignature, $method->getDsSignature());
+        $this->assertEquals('', $method->getDsSignatureVersion());
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysOrderTransformerTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysOrderTransformerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\Services;
+
+use PaymentSuite\RedsysBundle\Services\RedsysOrderTransformer;
+use PHPUnit\Framework\TestCase;
+
+class RedsysOrderTransformerTest extends TestCase
+{
+    public function testTransform()
+    {
+        $transformer = new RedsysOrderTransformer();
+
+        $order = $transformer->transform(1234);
+
+        $this->assertEquals('1234T4957086', $order);
+    }
+
+    public function testReverseTransform()
+    {
+        $transformer = new RedsysOrderTransformer();
+
+        $order = $transformer->reverseTransform('1234T4957086');
+
+        $this->assertEquals(1234, $order);
+    }
+}
+
+namespace PaymentSuite\RedsysBundle\Services;
+
+function time()
+{
+    return 1556807594;
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysSignatureFactoryTest.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/Services/RedsysSignatureFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\Services;
+
+use PaymentSuite\RedsysBundle\RedsysSignature;
+use PaymentSuite\RedsysBundle\Services\RedsysSignatureFactory;
+use PHPUnit\Framework\TestCase;
+
+class RedsysSignatureFactoryTest extends TestCase
+{
+    /**
+     * @var RedsysSignatureFactory
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $this->factory = new RedsysSignatureFactory('very-secret');
+    }
+
+    public function testCreateFromResultParameters()
+    {
+        $parameters = [
+            'Ds_Order' => '1234',
+        ];
+
+        $signature = $this->factory->createFromResultParameters($parameters);
+
+        $this->assertInstanceOf(RedsysSignature::class, $signature);
+        $this->assertEquals('4odzUxoEmWerdURFqh2pvmcyWM1UMmiRuY9d0OT5buY=', $signature->__toString());
+    }
+
+    public function testCreateFromMerchantParameters()
+    {
+
+        $parameters = [
+            'Ds_Merchant_Order' => '1234',
+        ];
+
+        $signature = $this->factory->createFromMerchantParameters($parameters);
+
+        $this->assertInstanceOf(RedsysSignature::class, $signature);
+        $this->assertEquals('IEOi8H5k2R1mi0ydMT6le36ySpvGR9vc4zsatFnbhic=', $signature->__toString());
+    }
+
+    public function testCreateFromResultString()
+    {
+        $signatureStr = 'IEOi8H5k2-_R1mi0ydMT6le36ySpvGR9vc4zsatFnbhic=';
+
+        $signature = $this->factory->createFromResultString($signatureStr);
+
+        $this->assertInstanceOf(RedsysSignature::class, $signature);
+        $this->assertEquals('IEOi8H5k2+/R1mi0ydMT6le36ySpvGR9vc4zsatFnbhic=', $signature->__toString());
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/app/RedsysKernel.php
+++ b/src/PaymentSuite/RedsysBundle/Tests/app/RedsysKernel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PaymentSuite\RedsysBundle\Tests\app;
+
+use PaymentSuite\PaymentCoreBundle\PaymentCoreBundle;
+use PaymentSuite\RedsysBundle\RedsysBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class RedsysKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new PaymentCoreBundle(),
+            new RedsysBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config/config.yml');
+    }
+}

--- a/src/PaymentSuite/RedsysBundle/Tests/app/config/config.yml
+++ b/src/PaymentSuite/RedsysBundle/Tests/app/config/config.yml
@@ -1,0 +1,37 @@
+parameters:
+    locale: en
+    secret: s3cr3t
+
+framework:
+    test: ~
+    session:
+        storage_id: session.storage.filesystem
+        name: MOCKSESSID
+    translator:      { fallback: "%locale%" }
+    secret:          "%secret%"
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
+    form:            true
+    default_locale:  "%locale%"
+    templating:      { engines: ['twig'] }
+    profiler:
+        enabled: false
+        collect: false
+
+redsys:
+    merchant_code: "999888777"
+    secret_key: test-secret-key
+    payment_success:
+        route: paymentsuite_redsys_success
+        order_append: false
+    payment_failure:
+        route: paymentsuite_redsys_failure
+        order_append: false
+
+services:
+    paymentsuite.redsys.dummy_payment_bridge:
+        class: PaymentSuite\RedsysBundle\Tests\Fixtures\DummyPaymentBridge
+
+    paymentsuite.bridge:
+        alias: paymentsuite.redsys.dummy_payment_bridge
+        public: true

--- a/src/PaymentSuite/RedsysBundle/Tests/app/config/routing.yml
+++ b/src/PaymentSuite/RedsysBundle/Tests/app/config/routing.yml
@@ -1,0 +1,2 @@
+_redsys:
+    resource: '@RedsysBundle/Resources/config/routing.yml'

--- a/src/PaymentSuite/RedsysBundle/composer.json
+++ b/src/PaymentSuite/RedsysBundle/composer.json
@@ -22,7 +22,8 @@
     ],
     "require": {
         "php": "^5.4|^7.0",
-
+        "ext-openssl": "*",
+        "ext-json": "*",
         "symfony/framework-bundle": "^2.7|^3.0",
         "symfony/form": "^2.7|^3.0",
         "symfony/config": "^2.7|^3.0",
@@ -31,12 +32,12 @@
         "symfony/dependency-injection": "^2.7|^3.0",
         "mmoreram/symfony-bundle-dependencies": "^1.0",
         "twig/twig": "^1.23.1",
-
         "paymentsuite/payment-core-bundle": "^2.0"
     },
     "require-dev": {
         "elcodi/test-common-bundle": "^2.0",
         "elcodi/fixtures-booster-bundle": "^2.0",
+        "symfony/twig-bundle": "^2.7|^3.0",
         "phpunit/phpunit": "<6.0"
     },
     "autoload": {

--- a/src/PaymentSuite/RedsysBundle/phpunit.xml.dist
+++ b/src/PaymentSuite/RedsysBundle/phpunit.xml.dist
@@ -8,9 +8,12 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="true"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
         >
+    <php>
+        <env name="KERNEL_CLASS" value="PaymentSuite\RedsysBundle\Tests\app\RedsysKernel" />
+    </php>
+
     <testsuites>
         <testsuite name="RedsysBundle Test Suite">
             <directory>./Tests</directory>

--- a/src/PaymentSuite/StripeBundle/DependencyInjection/Configuration.php
+++ b/src/PaymentSuite/StripeBundle/DependencyInjection/Configuration.php
@@ -16,7 +16,6 @@
 namespace PaymentSuite\StripeBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-
 use PaymentSuite\PaymentCoreBundle\DependencyInjection\Abstracts\AbstractPaymentSuiteConfiguration;
 
 /**
@@ -61,6 +60,16 @@ class Configuration extends AbstractPaymentSuiteConfiguration
             ->append($this->addRouteConfiguration('payment_failure'))
         ->end();
 
+        $this->addSettingsProviderConfiguration($rootNode);
+
         return $treeBuilder;
+    }
+
+    protected function setDefaultSettings($config)
+    {
+        $config['public_key'] = 'public_dummy';
+        $config['private_key'] = 'private_dummy';
+
+        return $config;
     }
 }

--- a/src/PaymentSuite/StripeBundle/DependencyInjection/StripeExtension.php
+++ b/src/PaymentSuite/StripeBundle/DependencyInjection/StripeExtension.php
@@ -61,5 +61,11 @@ class StripeExtension extends AbstractPaymentSuiteExtension
         $loader->load('controllers.yml');
         $loader->load('services.yml');
         $loader->load('twig.yml');
+
+        $this->addSettingsProvider(
+            $container,
+            'stripe',
+            $config['settings_provider']
+        );
     }
 }

--- a/src/PaymentSuite/StripeBundle/Resources/config/services.yml
+++ b/src/PaymentSuite/StripeBundle/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
     paymentsuite.stripe.transaction_factory:
         class: PaymentSuite\StripeBundle\Services\StripeTransactionFactory
         arguments:
-            - '%paymentsuite.stripe.private_key%'
+            - '@paymentsuite.stripe.settings_provider'
             - '@paymentsuite.stripe.event_dispatcher'
 
     paymentsuite.stripe.manager:
@@ -26,12 +26,20 @@ services:
 
     paymentsuite.stripe.method_factory:
         class: PaymentSuite\StripeBundle\Services\StripeMethodFactory
+        arguments:
+            - '@paymentsuite.stripe.settings_provider'
 
     paymentsuite.stripe.template_render:
         class: PaymentSuite\StripeBundle\Services\StripeTemplateRender
         arguments:
             - '@paymentsuite.bridge'
             - '@form.factory'
-            - '%paymentsuite.stripe.public_key%'
+            - '@paymentsuite.stripe.settings_provider'
             - '%paymentsuite.stripe.view_template%'
             - '%paymentsuite.stripe.scripts_template%'
+
+    paymentsuite.stripe.settings_provider_default:
+        class: PaymentSuite\StripeBundle\Services\StripeSettingsProviderDefault
+        arguments:
+            - '%paymentsuite.stripe.private_key%'
+            - '%paymentsuite.stripe.public_key%'

--- a/src/PaymentSuite/StripeBundle/Services/Interfaces/StripeSettingsProviderInterface.php
+++ b/src/PaymentSuite/StripeBundle/Services/Interfaces/StripeSettingsProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PaymentSuite\StripeBundle\Services\Interfaces;
+
+use PaymentSuite\PaymentCoreBundle\PaymentMethodInterface;
+
+interface StripeSettingsProviderInterface extends PaymentMethodInterface
+{
+    /**
+     * Gets stripe public key.
+     *
+     * @return string
+     */
+    public function getPublicKey();
+
+    /**
+     * Gets stripe private key.
+     *
+     * @return string
+     */
+    public function getPrivateKey();
+}

--- a/src/PaymentSuite/StripeBundle/Services/StripeMethodFactory.php
+++ b/src/PaymentSuite/StripeBundle/Services/StripeMethodFactory.php
@@ -15,6 +15,7 @@
 
 namespace PaymentSuite\StripeBundle\Services;
 
+use PaymentSuite\StripeBundle\Services\Interfaces\StripeSettingsProviderInterface;
 use PaymentSuite\StripeBundle\StripeMethod;
 
 /**
@@ -22,6 +23,21 @@ use PaymentSuite\StripeBundle\StripeMethod;
  */
 class StripeMethodFactory
 {
+    /**
+     * @var StripeSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
+     * StripeMethodFactory constructor.
+     *
+     * @param StripeSettingsProviderInterface $settingsProvider
+     */
+    public function __construct(StripeSettingsProviderInterface $settingsProvider)
+    {
+        $this->settingsProvider = $settingsProvider;
+    }
+
     /**
      * Given some data, creates a StripeMethod object.
      *
@@ -43,6 +59,7 @@ class StripeMethodFactory
         $creditCardSecurity
     ) {
         return new StripeMethod(
+            $this->settingsProvider->getPaymentName(),
             $apiToken,
             $creditCardNumber,
             $creditCardOwner,

--- a/src/PaymentSuite/StripeBundle/Services/StripeSettingsProviderDefault.php
+++ b/src/PaymentSuite/StripeBundle/Services/StripeSettingsProviderDefault.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PaymentSuite\StripeBundle\Services;
+
+use PaymentSuite\StripeBundle\Services\Interfaces\StripeSettingsProviderInterface;
+
+class StripeSettingsProviderDefault implements StripeSettingsProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $privateKey;
+
+    /**
+     * @var string
+     */
+    private $publicKey;
+
+    /**
+     * PaypalWebCheckoutSettingsProviderDefault constructor.
+     *
+     * @param string $privateKey
+     * @param string $publicKey
+     */
+    public function __construct($privateKey, $publicKey)
+    {
+        $this->privateKey = $privateKey;
+        $this->publicKey = $publicKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPublicKey()
+    {
+        return $this->publicKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrivateKey()
+    {
+        return $this->privateKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaymentName()
+    {
+        return 'Stripe';
+    }
+}

--- a/src/PaymentSuite/StripeBundle/Services/StripeTemplateRender.php
+++ b/src/PaymentSuite/StripeBundle/Services/StripeTemplateRender.php
@@ -15,9 +15,9 @@
 
 namespace PaymentSuite\StripeBundle\Services;
 
+use PaymentSuite\StripeBundle\Services\Interfaces\StripeSettingsProviderInterface;
 use Symfony\Component\Form\FormFactory;
 use Twig_Environment;
-
 use PaymentSuite\PaymentCoreBundle\Services\Interfaces\PaymentBridgeInterface;
 
 /**
@@ -42,13 +42,6 @@ class StripeTemplateRender
     /**
      * @var string
      *
-     * Public key
-     */
-    private $publicKey;
-
-    /**
-     * @var string
-     *
      * View template name in Bundle notation
      */
     private $viewTemplate;
@@ -61,26 +54,31 @@ class StripeTemplateRender
     private $scriptsTemplate;
 
     /**
+     * @var StripeSettingsProviderInterface
+     */
+    private $settingsProvider;
+
+    /**
      * Construct method.
      *
-     * @param PaymentBridgeInterface $paymentBridgeInterface Payment Bridge Interface
-     * @param FormFactory            $formFactory            Form factory
-     * @param string                 $publicKey              Public key
-     * @param string                 $viewTemplate           Twig template name for displaying the form
-     * @param string                 $scriptsTemplate        Twig template name for scripts/js
+     * @param PaymentBridgeInterface          $paymentBridgeInterface Payment Bridge Interface
+     * @param FormFactory                     $formFactory            Form factory
+     * @param StripeSettingsProviderInterface $settingsProvider       Settings provider
+     * @param string                          $viewTemplate           Twig template name for displaying the form
+     * @param string                          $scriptsTemplate        Twig template name for scripts/js
      */
     public function __construct(
         PaymentBridgeInterface $paymentBridgeInterface,
         FormFactory $formFactory,
-        $publicKey,
+        StripeSettingsProviderInterface $settingsProvider,
         $viewTemplate,
         $scriptsTemplate
     ) {
         $this->paymentBridgeInterface = $paymentBridgeInterface;
         $this->formFactory = $formFactory;
-        $this->publicKey = $publicKey;
         $this->viewTemplate = $viewTemplate;
         $this->scriptsTemplate = $scriptsTemplate;
+        $this->settingsProvider = $settingsProvider;
     }
 
     /**
@@ -88,6 +86,10 @@ class StripeTemplateRender
      *
      * @param Twig_Environment $environment  Environment
      * @param bool             $viewTemplate View template
+     *
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
      */
     public function renderStripeForm(Twig_Environment $environment, $viewTemplate = null)
     {
@@ -103,11 +105,15 @@ class StripeTemplateRender
      * Render stripe scripts.
      *
      * @param Twig_Environment $environment Environment
+     *
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
      */
     public function renderStripeScripts(Twig_Environment $environment)
     {
         $environment->display($this->scriptsTemplate, [
-            'public_key' => $this->publicKey,
+            'public_key' => $this->settingsProvider->getPublicKey(),
             'currency' => $this->paymentBridgeInterface->getCurrency(),
         ]);
     }

--- a/src/PaymentSuite/StripeBundle/Services/StripeTransactionFactory.php
+++ b/src/PaymentSuite/StripeBundle/Services/StripeTransactionFactory.php
@@ -16,6 +16,7 @@
 namespace PaymentSuite\StripeBundle\Services;
 
 use Exception;
+use PaymentSuite\StripeBundle\Services\Interfaces\StripeSettingsProviderInterface;
 use PaymentSuite\StripeBundle\ValueObject\StripeTransaction;
 use Stripe\Charge;
 use Stripe\Customer;
@@ -27,25 +28,24 @@ use Stripe\Stripe;
 class StripeTransactionFactory
 {
     /**
-     * @var string
-     *
-     * Private key
-     */
-    private $privateKey;
-    /**
      * @var StripeEventDispatcher
      */
     private $dispatcher;
+    /**
+     * @var StripeSettingsProviderInterface
+     */
+    private $settingsProvider;
 
     /**
      * Construct method for stripe transaction wrapper.
      *
-     * @param string $privateKey Private key
+     * @param StripeSettingsProviderInterface $settingsProvider
+     * @param StripeEventDispatcher           $dispatcher
      */
-    public function __construct($privateKey, StripeEventDispatcher $dispatcher)
+    public function __construct(StripeSettingsProviderInterface $settingsProvider, StripeEventDispatcher $dispatcher)
     {
-        $this->privateKey = $privateKey;
         $this->dispatcher = $dispatcher;
+        $this->settingsProvider = $settingsProvider;
     }
 
     /**
@@ -58,7 +58,7 @@ class StripeTransactionFactory
     public function create(StripeTransaction $transaction)
     {
         try {
-            Stripe::setApiKey($this->privateKey);
+            Stripe::setApiKey($this->settingsProvider->getPrivateKey());
 
             $this->dispatcher->notifyCustomerPreCreate($transaction);
 

--- a/src/PaymentSuite/StripeBundle/StripeMethod.php
+++ b/src/PaymentSuite/StripeBundle/StripeMethod.php
@@ -24,13 +24,18 @@ use ArrayAccess;
 final class StripeMethod implements PaymentMethodInterface
 {
     /**
+     * @var string
+     */
+    private $paymentName;
+
+    /**
      * Get Stripe method name.
      *
      * @return string Payment name
      */
     public function getPaymentName()
     {
-        return 'Stripe';
+        return $this->paymentName;
     }
 
     /**
@@ -99,14 +104,16 @@ final class StripeMethod implements PaymentMethodInterface
     /**
      * Construct method.
      *
-     * @param string $apiToken                  Api token
-     * @param string $creditCardNumber          Credit card number
-     * @param string $creditCardOwner           Credit card owner
-     * @param string $creditCardExpirationYear  Credit card expiration year
+     * @param string $paymentName
+     * @param string $apiToken Api token
+     * @param string $creditCardNumber Credit card number
+     * @param string $creditCardOwner Credit card owner
+     * @param string $creditCardExpirationYear Credit card expiration year
      * @param string $creditCardExpirationMonth Credit card expiration month
-     * @param string $creditCardSecurity        Credit card security
+     * @param string $creditCardSecurity Credit card security
      */
     public function __construct(
+        $paymentName,
         $apiToken,
         $creditCardNumber,
         $creditCardOwner,
@@ -120,6 +127,7 @@ final class StripeMethod implements PaymentMethodInterface
         $this->creditCardExpirationYear = $creditCardExpirationYear;
         $this->creditCardExpirationMonth = $creditCardExpirationMonth;
         $this->creditCardSecurity = $creditCardSecurity;
+        $this->paymentName = $paymentName;
     }
 
     /**

--- a/src/PaymentSuite/StripeBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/PaymentSuite/StripeBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace PaymentSuite\StripeBundle\Tests\DependencyInjection;
+
+use PaymentSuite\StripeBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class ConfigurationTest extends TestCase
+{
+    public function testPublicKeyMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('public_key');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testPrivateKeyMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['public_key'] = 'test_key';
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('private_key');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testPaymentSuccessMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['private_key'] = 'test_key';
+        $inputConfig['public_key'] = 'test_key_2';
+        unset($inputConfig['payment_success']);
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('payment_success');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testPaymentFailureMustBeSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['private_key'] = 'test_key';
+        $inputConfig['public_key'] = 'test_key_2';
+        unset($inputConfig['payment_failure']);
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('payment_failure');
+
+        $configTree->finalize($normalizedConfig);
+    }
+
+    public function testMandatoryConfigMightNotBeSetIfCustomSettingsProviderIsSet()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['settings_provider'] = 'dummy_service_id';
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+        $expectedConfig['settings_provider'] = 'dummy_service_id';
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configTree = $configuration->getConfigTreeBuilder()->buildTree();
+
+        $inputConfig = $this->getRoutesConfiguration();
+        $inputConfig['private_key'] = 'private_dummy';
+        $inputConfig['public_key'] = 'public_dummy';
+
+        $normalizedConfig = $configTree->normalize($inputConfig);
+
+        $finalizedConfig = $configTree->finalize($normalizedConfig);
+
+        $expectedConfig = $this->getDefaultConfiguration();
+
+        $this->assertEquals($expectedConfig, $finalizedConfig);
+    }
+
+    private function getRoutesConfiguration()
+    {
+        return [
+            'payment_success' => [
+                'route' => 'test-route-success',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+            'payment_failure' => [
+                'route' => 'test-route-failure',
+                'order_append' => true,
+                'order_append_field' => 'id',
+            ],
+        ];
+    }
+
+    private function getDefaultConfiguration()
+    {
+        $config = $this->getRoutesConfiguration();
+        $config['settings_provider'] = 'default';
+        $config['api_endpoint'] = 'https://api.stripe.com/';
+        $config['private_key'] = 'private_dummy';
+        $config['public_key'] = 'public_dummy';
+        $config['templates'] = [
+            'view_template' => 'StripeBundle:Stripe:view.html.twig',
+            'scripts_template' => 'StripeBundle:Stripe:scripts.html.twig',
+        ];
+
+        return $config;
+    }
+}

--- a/src/PaymentSuite/StripeBundle/Tests/DependencyInjection/StripeExtensionTest.php
+++ b/src/PaymentSuite/StripeBundle/Tests/DependencyInjection/StripeExtensionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace PaymentSuite\StripeBundle\Tests\DependencyInjection;
+
+use PaymentSuite\PaymentCoreBundle\ValueObject\RedirectionRoute;
+use PaymentSuite\StripeBundle\Controller\PaymentController;
+use PaymentSuite\StripeBundle\DependencyInjection\StripeExtension;
+use PaymentSuite\StripeBundle\Services\StripeEventDispatcher;
+use PaymentSuite\StripeBundle\Services\StripeManager;
+use PaymentSuite\StripeBundle\Services\StripeMethodFactory;
+use PaymentSuite\StripeBundle\Services\StripeSettingsProviderDefault;
+use PaymentSuite\StripeBundle\Services\StripeTemplateRender;
+use PaymentSuite\StripeBundle\Services\StripeTransactionFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class StripeExtensionTest extends TestCase
+{
+    public function testLoadDefaults()
+    {
+        $configs = [
+            'stripe' => [
+                'settings_provider' => 'default',
+                'public_key' => 'public-key',
+                'private_key' => 'private-key',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_failure' => [
+                    'route' => 'test-route-failure',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new StripeExtension();
+        $extension->load($configs, $container);
+
+        //Parameters
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.private_key'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.public_key'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.api_endpoint'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.view_template'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.scripts_template'));
+
+        $this->assertSame('private-key', $container->getParameter('paymentsuite.stripe.private_key'));
+        $this->assertSame('public-key', $container->getParameter('paymentsuite.stripe.public_key'));
+        $this->assertSame('https://api.stripe.com/', $container->getParameter('paymentsuite.stripe.api_endpoint'));
+        $this->assertSame('StripeBundle:Stripe:view.html.twig', $container->getParameter('paymentsuite.stripe.view_template'));
+        $this->assertSame('StripeBundle:Stripe:scripts.html.twig', $container->getParameter('paymentsuite.stripe.scripts_template'));
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.stripe.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.stripe.route_success')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.route_failure'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.stripe.route_failure')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.stripe.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.stripe.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.stripe.event_dispatcher'));
+        $this->assertSame(StripeEventDispatcher::class, $container->getDefinition('paymentsuite.stripe.event_dispatcher')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.manager'));
+        $this->assertSame(StripeManager::class, $container->getDefinition('paymentsuite.stripe.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.template_render'));
+        $this->assertSame(StripeTemplateRender::class, $container->getDefinition('paymentsuite.stripe.template_render')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.method_factory'));
+        $this->assertSame(StripeMethodFactory::class, $container->getDefinition('paymentsuite.stripe.method_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.transaction_factory'));
+        $this->assertSame(StripeTransactionFactory::class, $container->getDefinition('paymentsuite.stripe.transaction_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.stripe.settings_provider_default'));
+        $this->assertSame(StripeSettingsProviderDefault::class, $container->getDefinition('paymentsuite.stripe.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.stripe.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.stripe.settings_provider');
+        $this->assertSame('paymentsuite.stripe.settings_provider_default', $settingsProvider->__toString());
+    }
+
+    public function testLoadCustomSettingsProvider()
+    {
+        $configs = [
+            'stripe' => [
+                'settings_provider' => 'test.dummy_settings_provider',
+                'payment_success' => [
+                    'route' => 'test-route-success',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+                'payment_failure' => [
+                    'route' => 'test-route-failure',
+                    'order_append' => true,
+                    'order_append_field' => 'id',
+                ],
+            ],
+        ];
+
+        $container = new ContainerBuilder();
+
+        $extension = new StripeExtension();
+        $extension->load($configs, $container);
+
+        //Parameters
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.private_key'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.public_key'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.api_endpoint'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.view_template'));
+        $this->assertTrue($container->hasParameter('paymentsuite.stripe.scripts_template'));
+
+        $this->assertSame('private_dummy', $container->getParameter('paymentsuite.stripe.private_key'));
+        $this->assertSame('public_dummy', $container->getParameter('paymentsuite.stripe.public_key'));
+        $this->assertSame('https://api.stripe.com/', $container->getParameter('paymentsuite.stripe.api_endpoint'));
+        $this->assertSame('StripeBundle:Stripe:view.html.twig', $container->getParameter('paymentsuite.stripe.view_template'));
+        $this->assertSame('StripeBundle:Stripe:scripts.html.twig', $container->getParameter('paymentsuite.stripe.scripts_template'));
+
+        //Routes
+        $this->assertTrue($container->has('paymentsuite.stripe.route_success'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.stripe.route_success')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.route_failure'));
+        $this->assertSame(RedirectionRoute::class, $container->getDefinition('paymentsuite.stripe.route_failure')->getClass());
+
+        //Controllers
+        $this->assertTrue($container->has('paymentsuite.stripe.payment_controller'));
+        $this->assertSame(PaymentController::class, $container->getDefinition('paymentsuite.stripe.payment_controller')->getClass());
+
+        //Services
+        $this->assertTrue($container->has('paymentsuite.stripe.event_dispatcher'));
+        $this->assertSame(StripeEventDispatcher::class, $container->getDefinition('paymentsuite.stripe.event_dispatcher')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.manager'));
+        $this->assertSame(StripeManager::class, $container->getDefinition('paymentsuite.stripe.manager')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.template_render'));
+        $this->assertSame(StripeTemplateRender::class, $container->getDefinition('paymentsuite.stripe.template_render')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.method_factory'));
+        $this->assertSame(StripeMethodFactory::class, $container->getDefinition('paymentsuite.stripe.method_factory')->getClass());
+        $this->assertTrue($container->has('paymentsuite.stripe.transaction_factory'));
+        $this->assertSame(StripeTransactionFactory::class, $container->getDefinition('paymentsuite.stripe.transaction_factory')->getClass());
+
+        //Settings provider
+        $this->assertTrue($container->has('paymentsuite.stripe.settings_provider_default'));
+        $this->assertSame(StripeSettingsProviderDefault::class, $container->getDefinition('paymentsuite.stripe.settings_provider_default')->getClass());
+
+        $this->assertTrue($container->has('paymentsuite.stripe.settings_provider'));
+        $settingsProvider = $container->getAlias('paymentsuite.stripe.settings_provider');
+        $this->assertSame('test.dummy_settings_provider', $settingsProvider->__toString());
+    }
+}

--- a/src/PaymentSuite/StripeBundle/Tests/Services/StripeMethodFactoryTest.php
+++ b/src/PaymentSuite/StripeBundle/Tests/Services/StripeMethodFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PaymentSuite\StripeBundle\Tests\Services;
+
+use PaymentSuite\StripeBundle\Services\Interfaces\StripeSettingsProviderInterface;
+use PaymentSuite\StripeBundle\Services\StripeMethodFactory;
+use PaymentSuite\StripeBundle\StripeMethod;
+use PHPUnit\Framework\TestCase;
+
+class StripeMethodFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $paymentName = 'test_payment_name';
+        $apiToken = 'test_token';
+        $creditCardNumber = '1234123412341234';
+        $creditCardOwner = 'test owner';
+        $creditCardExpirationYear = '19';
+        $creditCardExpirationMonth = '12';
+        $creditCardSecurity = '987';
+
+        $settingsProvider = $this->prophesize(StripeSettingsProviderInterface::class);
+        $settingsProvider
+            ->getPaymentName()
+            ->shouldBeCalled()
+            ->willReturn($paymentName);
+
+        $factory = new StripeMethodFactory($settingsProvider->reveal());
+
+        $paymentMethod = $factory->create(
+            $apiToken,
+            $creditCardNumber,
+            $creditCardOwner,
+            $creditCardExpirationYear,
+            $creditCardExpirationMonth,
+            $creditCardSecurity
+        );
+
+        $this->assertInstanceOf(StripeMethod::class, $paymentMethod);
+        $this->assertEquals($paymentName, $paymentMethod->getPaymentName());
+        $this->assertEquals($apiToken, $paymentMethod->getApiToken());
+        $this->assertEquals($creditCardNumber, $paymentMethod->getCreditCardNumber());
+        $this->assertEquals($creditCardOwner, $paymentMethod->getCreditCardOwner());
+        $this->assertEquals($creditCardExpirationYear, $paymentMethod->getCreditCardExpirationYear());
+        $this->assertEquals($creditCardExpirationMonth, $paymentMethod->getCreditCardExpirationMonth());
+        $this->assertEquals($creditCardSecurity, $paymentMethod->getCreditCardSecurity());
+    }
+}

--- a/src/PaymentSuite/StripeBundle/Tests/Services/StripeSettingsProviderDefaultTest.php
+++ b/src/PaymentSuite/StripeBundle/Tests/Services/StripeSettingsProviderDefaultTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PaymentSuite\StripeBundle\Tests\Services;
+
+use PaymentSuite\StripeBundle\Services\StripeSettingsProviderDefault;
+use PHPUnit\Framework\TestCase;
+
+class StripeSettingsProviderDefaultTest extends TestCase
+{
+    public function testCreateService()
+    {
+        $privateKey = 'private';
+        $publicKey = 'public';
+
+        $service = new StripeSettingsProviderDefault($privateKey, $publicKey);
+
+        $this->assertEquals($privateKey, $service->getPrivateKey());
+        $this->assertEquals($publicKey, $service->getPublicKey());
+        $this->assertEquals('Stripe', $service->getPaymentName());
+    }
+}

--- a/src/PaymentSuite/StripeBundle/Tests/Services/StripeTransactionFactoryTest.php
+++ b/src/PaymentSuite/StripeBundle/Tests/Services/StripeTransactionFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace PaymentSuite\StripeBundle\Tests\Services;
 
+use PaymentSuite\StripeBundle\Services\Interfaces\StripeSettingsProviderInterface;
 use PaymentSuite\StripeBundle\Services\StripeEventDispatcher;
 use PaymentSuite\StripeBundle\Services\StripeTransactionFactory;
 use PaymentSuite\StripeBundle\ValueObject\EditableStripeTransaction;
@@ -11,12 +12,11 @@ use Prophecy\Prophecy\ObjectProphecy;
 
 class StripeTransactionFactoryTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testCreate()
     {
         $enableIntegrationTests = '1' == getenv('ENABLE_API_INTEGRATION') ? true : false;
 
-        if(!$enableIntegrationTests){
+        if (!$enableIntegrationTests) {
             $this->markTestSkipped('API integration tests disabled');
         }
 
@@ -26,7 +26,13 @@ class StripeTransactionFactoryTest extends \PHPUnit_Framework_TestCase
             ->notifyCustomerPreCreate(Argument::type(EditableStripeTransaction::class))
             ->shouldBeCalled();
 
-        $factory = new StripeTransactionFactory(getenv('STRIPE_API_KEY'), $dispatcher->reveal());
+        $settingsProvider = $this->prophesize(StripeSettingsProviderInterface::class);
+        $settingsProvider
+            ->getPrivateKey()
+            ->shouldBeCalled()
+            ->willReturn(getenv('STRIPE_API_KEY'));
+
+        $factory = new StripeTransactionFactory($settingsProvider->reveal(), $dispatcher->reveal());
 
         $charge = $factory->create(new StripeTransaction('tok_visa', 100, 'eur'));
 

--- a/src/PaymentSuite/StripeBundle/ValueObject/EditableStripeTransaction.php
+++ b/src/PaymentSuite/StripeBundle/ValueObject/EditableStripeTransaction.php
@@ -6,5 +6,5 @@ interface EditableStripeTransaction
 {
     public function setDescription($description);
     public function setEmail($email);
-    public function setMetadata(array $metadata);
+    public function setMetadata($metadata);
 }

--- a/src/PaymentSuite/StripeBundle/ValueObject/StripeTransaction.php
+++ b/src/PaymentSuite/StripeBundle/ValueObject/StripeTransaction.php
@@ -77,7 +77,7 @@ class StripeTransaction implements EditableStripeTransaction
      * @param mixed $metadata
      * @return StripeTransaction
      */
-    public function setMetadata(array $metadata)
+    public function setMetadata($metadata)
     {
         $this->metadata = $metadata;
         return $this;

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,2 @@
+[PHP]
+memory_limit = -1


### PR DESCRIPTION
creates paylands method in form type builder methods
add redsys terminal number configuration
add redsys new sha256 encryption logic
refactors paylands to use a settings provider
refactors stripe to use a settings provider
refactors free payment to use a settings provider
refactors bankwire to use a settings provider
adds extended configuration to allow the use of a settings provider
refactors paypal to use its own settings provider
remove type hinting